### PR TITLE
Documentation and repository touchups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+on: [push, pull_request]
+
+name: CI
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,9 @@ description = "Prefix based variable length integer coding."
 license = "MIT OR Apache-2.0"
 keywords = ["integer", "coding", "compression"]
 categories = ["compression"]
-
+repository = "https://github.com/mccullocht/prefix_varint"
+homepage = "https://github.com/mccullocht/prefix_varint"
+readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
-# `prefix_uvarint`
+# prefix_uvarint
 
-This module implements a prefix-based variable length integer coding scheme.
+[![Crates.io][crates-badge]][crates-url]
+
+[crates-badge]: https://img.shields.io/crates/v/prefix_uvarint.svg
+[crates-url]: https://crates.io/crates/prefix_uvarint
+
+This crate implements a prefix-based variable length integer coding scheme.
 
 Unlike an [LEB128](https://en.wikipedia.org/wiki/LEB128)-style encoding scheme, this encoding
 uses a unary prefix code in the first byte of the value to indicate how many subsequent bytes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub(crate) fn zigzag_decode(v: u64) -> i64 {
 
 /// Max value for an n-byte length.
 const MAX_VALUE: [u64; 10] = [
-    0x0,
+    0x0, // placeholder
     0x7f,
     0x3fff,
     0x1fffff,
@@ -68,8 +68,8 @@ const MAX_VALUE: [u64; 10] = [
 
 // Tag prefix value for an n-byte length to OR with the value.
 const TAG_PREFIX: [u64; 9] = [
-    0x0,
-    0x0,
+    0x0, // placeholder
+    0x0, // placeholder
     0x8000,
     0xc00000,
     0xe0000000,
@@ -234,7 +234,7 @@ pub(crate) const MAX_1BYTE_TAG: u8 = MAX_VALUE[1] as u8;
 pub unsafe fn decode_prefix_uvarint(p: *const u8) -> (u64, usize) {
     let tag = std::ptr::read(p);
     if tag <= MAX_1BYTE_TAG {
-        return (tag.into(), 1);
+        (tag.into(), 1)
     } else {
         decode_prefix_uvarint_slow(tag, p)
     }
@@ -281,7 +281,7 @@ pub trait VarintBuf: bytes::Buf {
             self.advance(len);
             Some(value)
         } else if !self.has_remaining() {
-            return None;
+            None
         } else {
             let tag = self.get_u8();
             if tag <= MAX_1BYTE_TAG {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,14 @@ unsafe fn encode_prefix_uvarint_slow(v: u64, p: *mut u8) -> usize {
 
 /// Encodes `v` as a prefix uvarint to `p`.
 ///
-/// This may write up to `MAX_LEN` bytes and may panic if fewer bytes are available.
+/// This may write up to `MAX_LEN` bytes and may panic if fewer bytes are
+/// available.
+///
+/// # Safety
+///
+/// This method may overread/overwrite memory if `p` is not at least `MAX_LEN`
+/// bytes long. It is the caller's responsibility to ensure that `p` is valid
+/// for writes of `MAX_LEN` bytes.
 #[inline]
 pub unsafe fn encode_prefix_uvarint(v: u64, p: *mut u8) -> usize {
     if v <= MAX_VALUE[1] {
@@ -130,7 +137,14 @@ pub unsafe fn encode_prefix_uvarint(v: u64, p: *mut u8) -> usize {
 
 /// Encodes `v` as a prefix varint to `p`.
 ///
-/// This may write up to `MAX_LEN` bytes and may panic if fewer bytes are available.
+/// This may write up to `MAX_LEN` bytes and may panic if fewer bytes are
+/// available.
+///
+/// # Safety
+///
+/// This method may overread/overwrite memory if `p` is not at least `MAX_LEN`
+/// bytes long. It is the caller's responsibility to ensure that `p` is valid
+/// for writes of `MAX_LEN` bytes.
 #[inline]
 pub unsafe fn encode_prefix_varint(v: i64, p: *mut u8) -> usize {
     encode_prefix_uvarint(zigzag_encode(v), p)
@@ -227,9 +241,17 @@ pub(crate) unsafe fn decode_prefix_uvarint_slow(tag: u8, p: *const u8) -> (u64, 
 
 pub(crate) const MAX_1BYTE_TAG: u8 = MAX_VALUE[1] as u8;
 
-/// Decodes a prefix uvarint value from `p`, returning the value and the number of bytes consumed.
+/// Decodes a prefix uvarint value from `p`, returning the value and the number
+/// of bytes consumed.
 ///
-/// This function may read up to `MAX_LEN` bytes from `p` and may panic if fewer bytes are available.
+/// This function may read up to `MAX_LEN` bytes from `p` and may panic if fewer
+/// bytes are available.
+///
+/// # Safety
+///
+/// This method may overread memory if `p` is not at least `MAX_LEN` bytes long.
+/// It is the caller's responsibility to ensure that `p` is valid for reads of
+/// `MAX_LEN` bytes.
 #[inline]
 pub unsafe fn decode_prefix_uvarint(p: *const u8) -> (u64, usize) {
     let tag = std::ptr::read(p);
@@ -240,9 +262,17 @@ pub unsafe fn decode_prefix_uvarint(p: *const u8) -> (u64, usize) {
     }
 }
 
-/// Decodes a prefix varint value from `p`, returning the value and the number of bytes consumed.
+/// Decodes a prefix varint value from `p`, returning the value and the number
+/// of bytes consumed.
 ///
-/// This function may read up to `MAX_LEN` bytes from `p` and may panic if fewer bytes are available.
+/// This function may read up to `MAX_LEN` bytes from `p` and may panic if fewer
+/// bytes are available.
+///
+/// # Safety
+///
+/// This method may overread memory if `p` is not at least `MAX_LEN` bytes long.
+/// It is the caller's responsibility to ensure that `p` is valid for reads of
+/// `MAX_LEN` bytes.
 #[inline]
 pub unsafe fn decode_prefix_varint(p: *const u8) -> (i64, usize) {
     let (v, len) = decode_prefix_uvarint(p);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -41,7 +41,7 @@ mod raw {
 
 mod buf {
     use super::{bounds_i64, bounds_u64, generate_array, RANDOM_TEST_LEN};
-    use crate::{VarintBuf, VarintBufMut, MAX_VALUE};
+    use crate::{VarintBuf, VarintBufMut, MAX_VALUE, TAG_PREFIX};
 
     macro_rules! test_random_buf_put_get {
         ($name:ident, $bounds:ident, $put:ident, $get:ident) => {
@@ -95,6 +95,15 @@ mod buf {
             buf.put_prefix_uvarint(*v);
             let mut trunc = &buf[0..(buf.len() - 1)];
             assert_eq!(trunc.get_prefix_uvarint(), None, "{}", *v);
+        }
+    }
+
+    #[test]
+    fn max_val_and_tag_prefix_cancel() {
+        for i in 2..9 {
+            let tag = TAG_PREFIX[i];
+            let max = MAX_VALUE[i];
+            assert_eq!(tag & max, 0);
         }
     }
 }


### PR DESCRIPTION
Awesome crate and looking forward to helping out on this. Great timing too I had just been looking into this and was about to write one myself! 

This PR adds CI to make sure main doesn't break. This means clippy lints were updated too.

Did some benchmarks here https://github.com/cgbur/varint-benchmarking. Looks like reading is lacking compared to leb128 (could be a benchmarking issue). If its not the case then looks like there may be some work to make reads faster. Also enabling `lto` and `codegen-units=1` dropped the write size 1 performance which is odd. I really don't trust criterion most of the time so :/.

Sorry for this PR having different changes, a lot of small things.