### PR TITLE
Benchmark distributions by encoded value length

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,56 +1,75 @@
+use std::ops::RangeInclusive;
+
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use prefix_uvarint::{VarintBuf, VarintBufMut};
-use rand::distributions::Uniform;
+use rand::distributions::{Uniform, WeightedIndex};
 use rand::prelude::*;
 
+// Use a zipf-ian distribution of lengths.
+const WEIGHTS: [usize; 9] = [7560, 3780, 2520, 1890, 1512, 1260, 1080, 945, 840];
+// Empirically we need this length to get at least one element of every size when max_bytes=9.
+const ARRARY_LEN: usize = 1024;
+
+fn range_for_byte_size(nbytes: usize) -> RangeInclusive<u64> {
+    let min = if nbytes == 1 {
+        0
+    } else {
+        1 << ((nbytes - 1) * 7)
+    };
+    let max = if nbytes < 9 {
+        u64::MAX >> (64 - (7 * nbytes))
+    } else {
+        u64::MAX
+    };
+    min..=max
+}
+
+// Generate an array of len with values no larger than max_bytes with a zipf-ian distribution.
 fn generate_array(len: usize, max_bytes: usize) -> Vec<u64> {
-    let seed = &[0xabu8; 32];
-    let mut rng = StdRng::from_seed(*seed);
-    // Each output byte contains at most 7 bytes of the input value, except for 9 (all possible values).
-    let mut max_value = u64::MAX;
-    if max_bytes < 9 {
-        max_value >>= 64 - (7 * max_bytes);
-    }
-    let between = Uniform::from(1..max_value);
-    (0..len).map(|_| between.sample(&mut rng)).collect()
+    let mut len_rng = StdRng::from_seed([0xabu8; 32]);
+    let len_dist = WeightedIndex::new(&WEIGHTS[..max_bytes]).unwrap();
+    let mut value_rng = StdRng::from_seed([0xcdu8; 32]);
+    len_dist
+        .sample_iter(&mut len_rng)
+        .take(len)
+        .map(|n| Uniform::from(range_for_byte_size(n + 1)).sample(&mut value_rng))
+        .collect()
 }
 
 fn benchmark(c: &mut Criterion) {
-    for len in [8, 256] {
-        let mut encode_group = c.benchmark_group(format!("put_prefix_uvarint/{}", len));
-        encode_group.throughput(Throughput::Elements(len as u64));
-        for max_bytes in 1..=9 {
-            let input_value = generate_array(len, max_bytes);
-            encode_group.bench_with_input(format!("{}", max_bytes), &input_value, |b, iv| {
-                let mut output = Vec::with_capacity(len * max_bytes);
-                b.iter(|| {
-                    output.clear();
-                    for v in iv {
-                        output.put_prefix_uvarint(*v)
-                    }
-                    assert!(output.len() > 0);
-                });
+    let mut encode_group = c.benchmark_group("put_prefix_uvarint");
+    encode_group.throughput(Throughput::Elements(ARRARY_LEN as u64));
+    for max_bytes in 1..=9 {
+        let input_value = generate_array(ARRARY_LEN, max_bytes);
+        encode_group.bench_with_input(format!("{}", max_bytes), &input_value, |b, iv| {
+            let mut output = Vec::with_capacity(ARRARY_LEN * max_bytes);
+            b.iter(|| {
+                output.clear();
+                for v in iv {
+                    output.put_prefix_uvarint(*v)
+                }
+                assert!(output.len() > 0);
             });
-        }
+        });
     }
+    drop(encode_group);
 
-    for len in [8, 256] {
-        let mut decode_group = c.benchmark_group(format!("get_prefix_uvarint/{}", len));
-        decode_group.throughput(Throughput::Elements(len as u64));
-        for max_bytes in 1..=9 {
-            let mut encoded = Vec::with_capacity(len * max_bytes);
-            for v in generate_array(len, max_bytes) {
-                encoded.put_prefix_uvarint(v)
-            }
-            decode_group.bench_with_input(format!("{}", max_bytes), &encoded, |b, e| {
-                b.iter(|| {
-                    let mut b = e.as_slice();
-                    for _ in 0..len {
-                        assert!(b.get_prefix_uvarint().unwrap() > 0);
-                    }
-                });
-            });
+    let mut decode_group = c.benchmark_group("get_prefix_uvarint");
+    decode_group.throughput(Throughput::Elements(ARRARY_LEN as u64));
+    for max_bytes in 1..=9 {
+        let mut encoded = Vec::with_capacity(ARRARY_LEN * max_bytes);
+        for v in generate_array(ARRARY_LEN, max_bytes) {
+            encoded.put_prefix_uvarint(v)
         }
+        decode_group.bench_with_input(format!("{}", max_bytes), &encoded, |b, e| {
+            b.iter(|| {
+                let mut b = e.as_slice();
+                for _ in 0..ARRARY_LEN {
+                    b.get_prefix_uvarint().unwrap();
+                }
+                assert!(b.is_empty())
+            });
+        });
     }
 }
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -5,10 +5,12 @@ use prefix_uvarint::{VarintBuf, VarintBufMut};
 use rand::distributions::{Uniform, WeightedIndex};
 use rand::prelude::*;
 
-// Use a zipf-ian distribution of lengths.
-const WEIGHTS: [usize; 9] = [7560, 3780, 2520, 1890, 1512, 1260, 1080, 945, 840];
+// Uniform weights: equal probability of a value of each length.
+const UNIFORM_WEIGHTS: [usize; 9] = [1, 1, 1, 1, 1, 1, 1, 1, 1];
+// Zipf-like weights: decreasing but non-zero probability for larger values.
+const ZIPF_WEIGHTS: [usize; 9] = [7560, 3780, 2520, 1890, 1512, 1260, 1080, 945, 840];
 // Empirically we need this length to get at least one element of every size when max_bytes=9.
-const ARRARY_LEN: usize = 1024;
+const ARRAY_LEN: usize = 1024;
 
 fn range_for_byte_size(nbytes: usize) -> RangeInclusive<u64> {
     let min = if nbytes == 1 {
@@ -25,9 +27,9 @@ fn range_for_byte_size(nbytes: usize) -> RangeInclusive<u64> {
 }
 
 // Generate an array of len with values no larger than max_bytes with a zipf-ian distribution.
-fn generate_array(len: usize, max_bytes: usize) -> Vec<u64> {
+fn generate_array(len: usize, max_bytes: usize, weights: &[usize; 9]) -> Vec<u64> {
     let mut len_rng = StdRng::from_seed([0xabu8; 32]);
-    let len_dist = WeightedIndex::new(&WEIGHTS[..max_bytes]).unwrap();
+    let len_dist = WeightedIndex::new(&weights[..max_bytes]).unwrap();
     let mut value_rng = StdRng::from_seed([0xcdu8; 32]);
     len_dist
         .sample_iter(&mut len_rng)
@@ -37,39 +39,44 @@ fn generate_array(len: usize, max_bytes: usize) -> Vec<u64> {
 }
 
 fn benchmark(c: &mut Criterion) {
-    let mut encode_group = c.benchmark_group("put_prefix_uvarint");
-    encode_group.throughput(Throughput::Elements(ARRARY_LEN as u64));
-    for max_bytes in 1..=9 {
-        let input_value = generate_array(ARRARY_LEN, max_bytes);
-        encode_group.bench_with_input(format!("{}", max_bytes), &input_value, |b, iv| {
-            let mut output = Vec::with_capacity(ARRARY_LEN * max_bytes);
-            b.iter(|| {
-                output.clear();
-                for v in iv {
-                    output.put_prefix_uvarint(*v)
-                }
-                assert!(output.len() > 0);
-            });
-        });
-    }
-    drop(encode_group);
+    for (name, weights) in [("uniform", &UNIFORM_WEIGHTS), ("zipf", &ZIPF_WEIGHTS)] {
+        let mut g = c.benchmark_group(name);
+        g.throughput(Throughput::Elements(ARRAY_LEN as u64));
+        for max_bytes in 1..=9 {
+            let input_value = generate_array(ARRAY_LEN, max_bytes, weights);
+            g.bench_with_input(
+                format!("max_bytes{}/put_prefix_varint", max_bytes),
+                &input_value,
+                |b, iv| {
+                    let mut output = Vec::with_capacity(ARRAY_LEN * max_bytes);
+                    b.iter(|| {
+                        output.clear();
+                        for v in iv {
+                            output.put_prefix_uvarint(*v)
+                        }
+                        assert!(output.len() > 0);
+                    });
+                },
+            );
 
-    let mut decode_group = c.benchmark_group("get_prefix_uvarint");
-    decode_group.throughput(Throughput::Elements(ARRARY_LEN as u64));
-    for max_bytes in 1..=9 {
-        let mut encoded = Vec::with_capacity(ARRARY_LEN * max_bytes);
-        for v in generate_array(ARRARY_LEN, max_bytes) {
-            encoded.put_prefix_uvarint(v)
+            let mut encoded = Vec::with_capacity(ARRAY_LEN * max_bytes);
+            for v in input_value.iter().copied() {
+                encoded.put_prefix_uvarint(v);
+            }
+            g.bench_with_input(
+                format!("max_bytes{}/get_prefix_uvarint", max_bytes),
+                encoded.as_slice(),
+                |b, e| {
+                    b.iter(|| {
+                        let mut b = e;
+                        for _ in 0..ARRAY_LEN {
+                            b.get_prefix_uvarint().unwrap();
+                        }
+                        assert!(b.is_empty());
+                    })
+                },
+            );
         }
-        decode_group.bench_with_input(format!("{}", max_bytes), &encoded, |b, e| {
-            b.iter(|| {
-                let mut b = e.as_slice();
-                for _ in 0..ARRARY_LEN {
-                    b.get_prefix_uvarint().unwrap();
-                }
-                assert!(b.is_empty())
-            });
-        });
     }
 }
 


### PR DESCRIPTION
Benchmark two different distributions of values by encoded length:
* Uniform: equal probability of each encoded length.
* Zipf: higher probabilities for shorter encoded lengths following ~zipf distribution.

These benchmarks are run for input with max byte lengths `1..=9` to get a sense of performance depending on maximum size, which would also help predict performance if inputs are never larger than a certain value (like if input is `u32`).

Both of these are more realistic than the previous benchmarks which used a uniform distribution to generate input values
up to a certain encoded length -- which ensured that most values were of the longest length.