### PR TITLE
Rework interfaces and improve performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prefix_uvarint"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Trevor McCulloch <mccullocht@gmail.com>"]
 edition = "2021"
 description = "Prefix based variable length integer coding."

--- a/README.md
+++ b/README.md
@@ -5,28 +5,26 @@
 [crates-badge]: https://img.shields.io/crates/v/prefix_uvarint.svg
 [crates-url]: https://crates.io/crates/prefix_uvarint
 
-This crate implements a prefix-based variable length integer coding scheme.
+This module implements a prefix-based variable length integer coding scheme.
 
 Unlike an [LEB128](https://en.wikipedia.org/wiki/LEB128)-style encoding scheme, this encoding
 uses a unary prefix code in the first byte of the value to indicate how many subsequent bytes
 need to be read followed by the big endian encoding of any remaining bytes. This improves
-coding speed compared to LEB128 by reducing the number of branches required to code longer
-values.
+coding speed compared to LEB128 by reducing the number of branches evaluated to code longer
+values, and allows those branches to be different to improve branch mis-prediction.
 
-XXX this needs to be updated.
-`uvarint` methods code `u64` values, with values closer to zero producing smaller output.
-`varint` methods code `i64` values using a [Zigzag](https://en.wikipedia.org/wiki/Variable-length_quantity#Zigzag_encoding)
-encoding to ensure that small negative numbers produce small output.
+The `PrefixVarInt` trait is implemented for `u64`, `u32`, `u16`, `i64`, `i32`, and `i16`, with
+values closer to zero producing small output. Signed values are written using a [Zigzag](https://en.wikipedia.org/wiki/Variable-length_quantity#Zigzag_encoding)
+coding to ensure that small negative numbers produce small output.
 
-XXX this needs to be updated. prefer PrefixVarInt, PrefixVarIntBuf, PrefixVarIntBufMut over IO
-XXX for speed.
-Coding methods are provided as extensions to the `bytes::{Buf,BufMut}` traits which are
-implemented for common in-memory byte stream types. Lower level methods that operate directly
-on pointers are also provided but come with caveats (may overread/overwrite).
+`PrefixVarInt` includes methods to code values directly to/from byte slices, but traits are
+provided to extend `bytes::{Buf,BufMut}`, and to handle these values in `std::io::{Write,Read}`.
 
 ## Performance
 
-XXX this needs to be updated.
-On an M1 MacbookAir compression speeds range from 250-450M elem/s depending on the lengths of the
-input values, with smaller values (`0..=127 u64` or `-64..=63 i64`) being the fastest. To get a
-sense of how fast this is on your host run `cargo bench`.
+To get a sense of how fast this is on your host, run `cargo bench`.
+
+Benchmarks run with two value distributions: uniform by encoded length, and zipf by encoded length.
+On an M1 MacBookAir coding speeds average 1.2G elem/s for values that encode to a single byte,
+dropping off to around 400M elem/s for the longest (9 byte) values. The encoded length of a value
+(`PrefixVarInt::prefix_varint_len()`) averages 3G+ elem/s.

--- a/README.md
+++ b/README.md
@@ -13,16 +13,20 @@ need to be read followed by the big endian encoding of any remaining bytes. This
 coding speed compared to LEB128 by reducing the number of branches required to code longer
 values.
 
+XXX this needs to be updated.
 `uvarint` methods code `u64` values, with values closer to zero producing smaller output.
 `varint` methods code `i64` values using a [Zigzag](https://en.wikipedia.org/wiki/Variable-length_quantity#Zigzag_encoding)
 encoding to ensure that small negative numbers produce small output.
 
+XXX this needs to be updated. prefer PrefixVarInt, PrefixVarIntBuf, PrefixVarIntBufMut over IO
+XXX for speed.
 Coding methods are provided as extensions to the `bytes::{Buf,BufMut}` traits which are
 implemented for common in-memory byte stream types. Lower level methods that operate directly
 on pointers are also provided but come with caveats (may overread/overwrite).
 
 ## Performance
 
+XXX this needs to be updated.
 On an M1 MacbookAir compression speeds range from 250-450M elem/s depending on the lengths of the
 input values, with smaller values (`0..=127 u64` or `-64..=63 i64`) being the fastest. To get a
 sense of how fast this is on your host run `cargo bench`.

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,7 +1,7 @@
 use std::ops::RangeInclusive;
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use prefix_uvarint::PrefixVarInt;
+use prefix_uvarint::{PrefixVarIntBuf, PrefixVarIntBufMut};
 use rand::distributions::{Uniform, WeightedIndex};
 use rand::prelude::*;
 
@@ -52,7 +52,7 @@ fn benchmark(c: &mut Criterion) {
                     b.iter(|| {
                         output.clear();
                         for v in iv {
-                            v.encode_varint(&mut output);
+                            output.put_prefix_varint(*v);
                         }
                         assert!(output.len() > 0);
                     });
@@ -61,7 +61,7 @@ fn benchmark(c: &mut Criterion) {
 
             let mut encoded = Vec::with_capacity(ARRAY_LEN * max_bytes);
             for v in input_value.iter().copied() {
-                v.encode_varint(&mut encoded);
+                encoded.put_prefix_varint(v);
             }
             g.bench_with_input(
                 format!("max_bytes{}/get_prefix_uvarint", max_bytes),
@@ -70,7 +70,7 @@ fn benchmark(c: &mut Criterion) {
                     b.iter(|| {
                         let mut b = e;
                         for _ in 0..ARRAY_LEN {
-                            u64::decode_varint(&mut b).unwrap();
+                            b.get_prefix_varint::<u64>().unwrap();
                         }
                         assert!(b.is_empty());
                     })

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -64,6 +64,7 @@ fn benchmark(c: &mut Criterion) {
                 encoded.put_prefix_varint(v);
             }
             g.bench_with_input(
+                // XXX fix name
                 format!("max_bytes{}/get_prefix_uvarint", max_bytes),
                 encoded.as_slice(),
                 |b, e| {

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -64,8 +64,7 @@ fn benchmark(c: &mut Criterion) {
                 encoded.put_prefix_varint(v);
             }
             g.bench_with_input(
-                // XXX fix name
-                format!("max_bytes{}/get_prefix_uvarint", max_bytes),
+                format!("max_bytes{}/get_prefix_varint", max_bytes),
                 encoded.as_slice(),
                 |b, e| {
                     b.iter(|| {

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,7 +1,7 @@
 use std::ops::RangeInclusive;
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use prefix_uvarint::{PrefixVarIntBuf, PrefixVarIntBufMut};
+use prefix_uvarint::{PrefixVarInt, PrefixVarIntBuf, PrefixVarIntBufMut};
 use rand::distributions::{Uniform, WeightedIndex};
 use rand::prelude::*;
 
@@ -74,6 +74,16 @@ fn benchmark(c: &mut Criterion) {
                             b.get_prefix_varint::<u64>().unwrap();
                         }
                         assert!(b.is_empty());
+                    })
+                },
+            );
+
+            g.bench_with_input(
+                format!("max_bytes{}/len", max_bytes),
+                &input_value,
+                |b, iv| {
+                    b.iter(|| {
+                        assert!(iv.iter().map(|v| v.prefix_varint_len()).sum::<usize>() > 0);
                     })
                 },
             );

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,7 +1,7 @@
 use std::ops::RangeInclusive;
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use prefix_uvarint::{VarintBuf, VarintBufMut};
+use prefix_uvarint::PrefixVarInt;
 use rand::distributions::{Uniform, WeightedIndex};
 use rand::prelude::*;
 
@@ -52,7 +52,7 @@ fn benchmark(c: &mut Criterion) {
                     b.iter(|| {
                         output.clear();
                         for v in iv {
-                            output.put_prefix_uvarint(*v)
+                            v.encode_varint(&mut output);
                         }
                         assert!(output.len() > 0);
                     });
@@ -61,7 +61,7 @@ fn benchmark(c: &mut Criterion) {
 
             let mut encoded = Vec::with_capacity(ARRAY_LEN * max_bytes);
             for v in input_value.iter().copied() {
-                encoded.put_prefix_uvarint(v);
+                v.encode_varint(&mut encoded);
             }
             g.bench_with_input(
                 format!("max_bytes{}/get_prefix_uvarint", max_bytes),
@@ -70,7 +70,7 @@ fn benchmark(c: &mut Criterion) {
                     b.iter(|| {
                         let mut b = e;
                         for _ in 0..ARRAY_LEN {
-                            b.get_prefix_uvarint().unwrap();
+                            u64::decode_varint(&mut b).unwrap();
                         }
                         assert!(b.is_empty());
                     })

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,0 +1,81 @@
+//! Traits that allow writing/reading `PrefixVarInt` types on `bytes::{BufMut,Buf}`.
+
+use crate::{
+    decode_prefix_uvarint, DecodeError, PrefixVarInt, MAX_1BYTE_TAG, MAX_LEN, MAX_VALUE, TAG_PREFIX,
+};
+use bytes::{Buf, BufMut};
+
+fn put_prefix_varint_slow<B: BufMut>(v: u64, buf: &mut B) -> usize {
+    if v <= MAX_VALUE[8] {
+        let len = v.prefix_varint_len();
+        buf.put_uint(v | TAG_PREFIX[len], len);
+        len
+    } else {
+        buf.put_u8(u8::MAX);
+        buf.put_u64(v);
+        9
+    }
+}
+
+/// Extension for `buf::BufMut` to write any `PrefixVarInt` type.
+pub trait PrefixVarIntBufMut {
+    fn put_prefix_varint<PV: PrefixVarInt>(&mut self, v: PV);
+}
+
+impl<Inner: BufMut> PrefixVarIntBufMut for Inner {
+    #[inline]
+    fn put_prefix_varint<PV: PrefixVarInt>(&mut self, v: PV) {
+        let raw = v.to_prefix_varint_raw();
+        if raw <= crate::MAX_VALUE[1] {
+            self.put_u8(raw as u8);
+        } else if self.chunk_mut().len() >= MAX_LEN {
+            unsafe {
+                let len = crate::encode_prefix_uvarint_slow(raw, self.chunk_mut().as_mut_ptr());
+                self.advance_mut(len);
+            }
+        } else {
+            put_prefix_varint_slow(raw, self);
+        }
+    }
+}
+
+fn get_prefix_varint_slow<B: Buf>(tag: u8, buf: &mut B) -> Result<u64, DecodeError> {
+    let rem = tag.leading_ones() as usize;
+    if rem > buf.remaining() {
+        buf.advance(buf.remaining());
+        Err(DecodeError::UnexpectedEob)
+    } else if rem < 8 {
+        let raw = (u64::from(tag) << (rem * 8)) | buf.get_uint(rem);
+        Ok(raw & MAX_VALUE[rem + 1])
+    } else {
+        Ok(buf.get_u64())
+    }
+}
+
+/// Extension for `buf::Buf` to read any `PrefixVarInt` type.
+pub trait PrefixVarIntBuf {
+    fn get_prefix_varint<PV: PrefixVarInt>(&mut self) -> Result<PV, DecodeError>;
+}
+
+impl<Inner: Buf> PrefixVarIntBuf for Inner {
+    #[inline]
+    fn get_prefix_varint<PV: PrefixVarInt>(&mut self) -> Result<PV, DecodeError> {
+        if self.remaining() == 0 {
+            return Err(DecodeError::UnexpectedEob);
+        }
+
+        if self.chunk().len() >= MAX_LEN || self.remaining() == self.chunk().len() {
+            let (raw, len) = unsafe { decode_prefix_uvarint(self.chunk().as_ptr()) };
+            self.advance(len);
+            return PV::from_prefix_varint_raw(raw).ok_or(DecodeError::Overflow);
+        }
+
+        let tag = self.get_u8();
+        if tag <= MAX_1BYTE_TAG {
+            PV::from_prefix_varint_raw(tag.into()).ok_or(DecodeError::Overflow)
+        } else {
+            PV::from_prefix_varint_raw(get_prefix_varint_slow(tag, self)?)
+                .ok_or(DecodeError::Overflow)
+        }
+    }
+}

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,0 +1,124 @@
+use crate::MAX_LEN;
+
+/// Base integer trait for prefix varints. Provides internal APIs to facilitate the transforms in
+/// the PrefixVarInt trait.
+pub trait Int: Sized + Copy {
+    fn to_prefix_varint_raw(self) -> u64;
+    fn from_prefix_varint_raw(r: u64) -> Option<Self>;
+}
+
+impl Int for u64 {
+    #[inline(always)]
+    fn to_prefix_varint_raw(self) -> u64 {
+        self
+    }
+    #[inline(always)]
+    fn from_prefix_varint_raw(raw: u64) -> Option<Self> {
+        Some(raw)
+    }
+}
+
+impl Int for i64 {
+    #[inline(always)]
+    fn to_prefix_varint_raw(self) -> u64 {
+        crate::zigzag_encode(self)
+    }
+    #[inline(always)]
+    fn from_prefix_varint_raw(raw: u64) -> Option<Self> {
+        Some(crate::zigzag_decode(raw))
+    }
+}
+
+macro_rules! impl_int {
+    ($int:ty, $pint:ty) => {
+        impl Int for $int {
+            #[inline(always)]
+            fn to_prefix_varint_raw(self) -> u64 {
+                <$pint>::from(self).to_prefix_varint_raw()
+            }
+            #[inline(always)]
+            fn from_prefix_varint_raw(raw: u64) -> Option<Self> {
+                let v = <$pint>::from_prefix_varint_raw(raw)?;
+                v.try_into().ok()
+            }
+        }
+    };
+}
+impl_int!(u16, u64);
+impl_int!(u32, u64);
+impl_int!(i16, i64);
+impl_int!(i32, i64);
+
+#[inline(always)]
+fn decode_prefix_varint_raw(buf: &[u8]) -> Result<(u64, usize), crate::DecodeError> {
+    if buf.is_empty() {
+        return Err(crate::DecodeError::UnexpectedEob);
+    }
+
+    if buf.len() >= MAX_LEN {
+        return Ok(unsafe { crate::decode_prefix_uvarint(buf.as_ptr()) });
+    }
+
+    let tag = buf[0];
+    if tag <= crate::MAX_1BYTE_TAG {
+        return Ok((tag.into(), 1));
+    }
+
+    let len = tag.leading_ones() as usize + 1;
+    if len <= buf.len() {
+        let mut ibuf = [0u8; crate::MAX_LEN];
+        ibuf[..len].copy_from_slice(buf);
+        Ok(unsafe { crate::decode_prefix_uvarint_slow(tag, ibuf.as_ptr()) })
+    } else {
+        Err(crate::DecodeError::UnexpectedEob)
+    }
+}
+
+/// Trait for integer types that can be prefix varint coded.
+///
+/// Signed integer types are zigzag coded before encoding/after decoding.
+pub trait PrefixVarInt: Sized + Copy + Int {
+    /// Returns the number of bytes required to encode `self`.
+    /// This value will always be in `[1, MAX_LEN]`
+    fn prefix_varint_len(self) -> usize {
+        crate::prefix_uvarint_len(self.to_prefix_varint_raw())
+    }
+
+    /// Encode `self` to buf and return the number of bytes written.
+    ///
+    /// # Panics
+    ///
+    /// If `self.prefix_varint_len() > buf.len()`.
+    fn encode_prefix_varint(self, buf: &mut [u8]) -> usize {
+        if buf.len() >= crate::MAX_LEN {
+            unsafe { crate::encode_prefix_uvarint(self.to_prefix_varint_raw(), buf.as_mut_ptr()) }
+        } else {
+            let enc = self.to_prefix_varint_bytes();
+            let ebytes = enc.as_slice();
+            buf[..ebytes.len()].copy_from_slice(ebytes);
+            ebytes.len()
+        }
+    }
+
+    /// Decode an integer from the bytes in `buf` and return the value and number of bytes consumed.
+    fn decode_prefix_varint(buf: &[u8]) -> Result<(Self, usize), crate::DecodeError> {
+        let (raw, len) = decode_prefix_varint_raw(buf)?;
+        Ok((
+            Self::from_prefix_varint_raw(raw).ok_or(crate::DecodeError::Overflow)?,
+            len,
+        ))
+    }
+
+    /// Encode `self` to an owned buffer and return it.
+    /// Use `as_slice()` to access the encoded bytes.
+    fn to_prefix_varint_bytes(self) -> crate::EncodedPrefixVarint {
+        crate::EncodedPrefixVarint::new(self.to_prefix_varint_raw())
+    }
+}
+
+impl PrefixVarInt for u16 {}
+impl PrefixVarInt for u32 {}
+impl PrefixVarInt for u64 {}
+impl PrefixVarInt for i16 {}
+impl PrefixVarInt for i32 {}
+impl PrefixVarInt for i64 {}

--- a/src/core.rs
+++ b/src/core.rs
@@ -67,7 +67,7 @@ fn decode_prefix_varint_raw(buf: &[u8]) -> Result<(u64, usize), crate::DecodeErr
     let len = tag.leading_ones() as usize + 1;
     if len <= buf.len() {
         let mut ibuf = [0u8; crate::MAX_LEN];
-        ibuf[..len].copy_from_slice(buf);
+        ibuf[..len].copy_from_slice(&buf[..len]);
         Ok(unsafe { crate::decode_prefix_uvarint_slow(tag, ibuf.as_ptr()) })
     } else {
         Err(crate::DecodeError::UnexpectedEob)

--- a/src/core.rs
+++ b/src/core.rs
@@ -88,7 +88,7 @@ pub trait PrefixVarInt: Sized + Copy + Int {
     ///
     /// # Panics
     ///
-    /// If `self.prefix_varint_len() > buf.len()`.
+    /// If `self.prefix_varint_len() > buf.remaining()`.
     fn encode_prefix_varint(self, buf: &mut [u8]) -> usize {
         if buf.len() >= crate::MAX_LEN {
             unsafe { crate::encode_prefix_uvarint(self.to_prefix_varint_raw(), buf.as_mut_ptr()) }

--- a/src/io.rs
+++ b/src/io.rs
@@ -40,7 +40,7 @@ impl<Inner: BufRead> PrefixVarIntRead for Inner {
     fn read_prefix_varint<PV: PrefixVarInt>(&mut self) -> Result<PV> {
         let buf = self.fill_buf()?;
         if buf.len() >= MAX_LEN {
-            let (v, len) = PV::decode_prefix_varint(buf).map_err(|e| Error::from(e))?;
+            let (v, len) = PV::decode_prefix_varint(buf).map_err(Error::from)?;
             self.consume(len);
             Ok(v)
         } else {
@@ -48,7 +48,8 @@ impl<Inner: BufRead> PrefixVarIntRead for Inner {
             self.read_exact(&mut buf[..1])?;
             let tag = buf[0];
             if tag <= crate::MAX_1BYTE_TAG {
-                return PV::from_prefix_varint_raw(tag.into()).ok_or(DecodeError::Overflow.into());
+                return PV::from_prefix_varint_raw(tag.into())
+                    .ok_or_else(|| DecodeError::Overflow.into());
             }
             let rem = tag.leading_ones() as usize;
             self.read_exact(&mut buf[1..(1 + rem)])?;

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,92 +1,61 @@
-//! Extensions to `std::io` traits to support reading/writing signed/unsigned prefix varints.
-//!
-//! `BufRead` should preferred over `Read` wherever possible as it should roughly halve the number
-//! of calls to the underlying reader.
-use std::io::{BufRead, Read, Result, Write};
+//! Extensions to `std::io` traits to support reading/writing prefix varints.
+use std::io::{BufRead, Error, ErrorKind, Result, Write};
 
-use crate::{
-    decode_prefix_uvarint, decode_prefix_uvarint_slow, encode_prefix_uvarint, zigzag_decode,
-    zigzag_encode, MAX_1BYTE_TAG, MAX_LEN,
-};
+use crate::{DecodeError, PrefixVarInt, MAX_LEN};
 
-/// Extensions for `std::io::Write` to write unsigned/signed prefix varints.
-pub trait VarintWrite: Write {
-    /// Write a prefix uvarint. Returns the number of bytes written.`
-    #[inline]
-    fn write_prefix_uvarint(&mut self, v: u64) -> Result<usize> {
-        let mut buf = [0u8; 16];
-        let len = unsafe { encode_prefix_uvarint(v, buf.as_mut_ptr()) };
-        self.write(&buf[..len])
-    }
-
-    /// Write a prefix varint. Returns the number of bytes written.`
-    #[inline]
-    fn write_prefix_varint(&mut self, v: i64) -> Result<usize> {
-        self.write_prefix_uvarint(zigzag_encode(v))
+impl From<DecodeError> for Error {
+    fn from(value: DecodeError) -> Self {
+        let kind = match value {
+            DecodeError::UnexpectedEob => ErrorKind::UnexpectedEof,
+            DecodeError::Overflow => ErrorKind::InvalidData,
+        };
+        Error::new(kind, value)
     }
 }
 
-/// Implement for all types that implement 'std::io::Write`.
-impl<W: Write + ?Sized> VarintWrite for W {}
-
-#[inline]
-fn read_prefix_uvarint_generic<R: Read + ?Sized>(r: &mut R) -> Result<u64> {
-    let mut buf = [0u8; 16];
-    r.read_exact(&mut buf[..1])?;
-    if buf[0] <= MAX_1BYTE_TAG {
-        return Ok(buf[0].into());
-    }
-
-    let extra_bytes = buf[0].leading_ones() as usize;
-    r.read_exact(&mut buf[1..(extra_bytes + 1)])?;
-    Ok(unsafe { decode_prefix_uvarint_slow(buf[0], buf.as_ptr()).0 })
+/// Extension for `std::io::Write` to write any `PrefixVarInt` type.
+pub trait PrefixVarIntWrite {
+    /// Write a prefix varint to an output stream.
+    fn write_prefix_varint<PV: PrefixVarInt>(&mut self, v: PV) -> Result<()>;
 }
 
-/// Extensions for `std::io::Read` to read unsigned/signed prefix varints.
-pub trait VarintRead: Read {
-    fn read_prefix_uvarint(&mut self) -> Result<u64>;
-    fn read_prefix_varint(&mut self) -> Result<i64>;
-}
-
-/// Implement for all types that implement `std::io::Read`.
-impl<R: Read + ?Sized> VarintRead for R {
-    /// Read a prefix uvarint, returning the value.
+/// Implement `PrefixVarIntWrite` for all types that implement `Write`.
+impl<Inner: Write> PrefixVarIntWrite for Inner {
     #[inline]
-    fn read_prefix_uvarint(&mut self) -> Result<u64> {
-        read_prefix_uvarint_generic(self)
-    }
-
-    /// Read a prefix varint, returning the value.
-    #[inline]
-    fn read_prefix_varint(&mut self) -> Result<i64> {
-        Ok(zigzag_decode(self.read_prefix_uvarint()?))
+    fn write_prefix_varint<PV: PrefixVarInt>(&mut self, v: PV) -> Result<()> {
+        self.write_all(v.to_prefix_varint_bytes().as_slice())
     }
 }
 
-/// Extensions for `std::io::BufRead` to read unsigned/signed prefix varints.
-pub trait VarintBufRead: BufRead {
-    fn read_prefix_uvarint(&mut self) -> Result<u64>;
-    fn read_prefix_varint(&mut self) -> Result<i64>;
+/// Extension for `std::io::BufRead` to read any `PrefixVarInt` type.
+pub trait PrefixVarIntRead {
+    // Read prefix varint from input, returning the value.
+    fn read_prefix_varint<PV: PrefixVarInt>(&mut self) -> Result<PV>;
 }
 
-/// Implement for all types that implement `std::io::BufRead`.
-impl<R: BufRead + ?Sized> VarintBufRead for R {
-    /// Read a prefix uvarint, returning the value.
+/// Implement `PrefixVarIntRead` for all types that implement `BufRead`.
+/// Note that `Read` is not supported -- the input ought to be buffered as reads will be small.
+impl<Inner: BufRead> PrefixVarIntRead for Inner {
     #[inline]
-    fn read_prefix_uvarint(&mut self) -> Result<u64> {
-        let buf = self.fill_buf()?;
+    fn read_prefix_varint<PV: PrefixVarInt>(&mut self) -> Result<PV> {
+        let mut buf = self.fill_buf()?;
         if buf.len() >= MAX_LEN {
-            let (v, len) = unsafe { decode_prefix_uvarint(buf.as_ptr()) };
+            // XXX this is hellaciously unergonomic.
+            let old_len = buf.len();
+            let v = PV::decode_varint(&mut buf).map_err(|e| Error::from(e))?;
+            let len = old_len - buf.len();
             self.consume(len);
             Ok(v)
         } else {
-            read_prefix_uvarint_generic(self)
+            let mut buf = [0u8; MAX_LEN];
+            self.read_exact(&mut buf[..1])?;
+            // XXX find a solution that allows us to bail early when buf[0] <= MAX_1BYTE_TAG
+            // this will also be a problem if PrefixVarInt stop encoding directly to BufMut.
+            let rem = buf[0].leading_ones() as usize;
+            if rem > 0 {
+                self.read_exact(&mut buf[1..(1 + rem)])?;
+            }
+            PV::decode_varint(&mut buf.as_slice()).map_err(|e| e.into())
         }
-    }
-
-    /// Read a prefix varint, returning the value.
-    #[inline]
-    fn read_prefix_varint(&mut self) -> Result<i64> {
-        Ok(zigzag_decode(VarintBufRead::read_prefix_uvarint(self)?))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,14 +16,19 @@
 //! XXX completely rewrite this example.
 //! ```
 //! use bytes::Buf;
-//! use prefix_uvarint::{PrefixVarIntBufMut, PrefixVarIntBuf};
+//! use prefix_uvarint::{PrefixVarInt, PrefixVarIntBufMut, PrefixVarIntBuf};
 //!
-//! let mut buf_mut = Vec::new();
+//! // value_buf is the maximum size needed to encode a value.
+//! let mut value_buf = [0u8; prefix_uvarint::MAX_LEN];
+//! assert_eq!(167894u64.encode_prefix_varint(&mut value_buf), 3);
+//! assert_eq!((167894u64, 3), u64::decode_prefix_varint(&value_buf).unwrap());
+//!
+//! let mut buf_mut = vec![];
 //! for v in (0..100).step_by(3) {
 //!   buf_mut.put_prefix_varint(v);
 //! }
 //!
-//! // NB: need a mutable slice to use as VarintBuf
+//! // NB: need a mutable slice to use as PrefixVarIntBufMut
 //! let mut buf = buf_mut.as_slice();
 //! while let Ok(v) = buf.get_prefix_varint::<u64>() {
 //!   assert_eq!(v % 3, 0);
@@ -39,7 +44,7 @@ mod tests;
 
 pub use crate::bytes::{PrefixVarIntBuf, PrefixVarIntBufMut};
 pub use crate::core::{DecodeError, EncodedPrefixVarInt, PrefixVarInt};
-pub use crate::io::{PrefixVarIntRead, PrefixVarIntWrite};
+pub use crate::io::{read_prefix_varint, read_prefix_varint_buf, write_prefix_varint};
 
 /// Maximum number of bytes a single encoded uvarint will occupy.
 pub const MAX_LEN: usize = 9;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@
 //! `PrefixVarInt` includes methods to code values directly to/from byte slices, but traits are
 //! provided to extend `bytes::{Buf,BufMut}`, and to handle these values in `std::io::{Write,Read}.
 //!
-//! XXX completely rewrite this example.
 //! ```
 //! use bytes::Buf;
 //! use prefix_uvarint::{PrefixVarInt, PrefixVarIntBufMut, PrefixVarIntBuf};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,15 +30,15 @@
 //! }
 //! assert!(!buf.has_remaining());
 //! ```
+mod bytes;
 pub(crate) mod core;
 mod io;
 #[cfg(test)]
 mod tests;
 
+pub use crate::bytes::{PrefixVarIntBuf, PrefixVarIntBufMut};
 pub use crate::core::PrefixVarInt;
 pub use crate::io::{PrefixVarIntRead, PrefixVarIntWrite};
-
-use bytes::buf::{Buf, BufMut};
 
 // XXX move to core, reexport in lib.
 /// Maximum number of bytes a single encoded uvarint will occupy.
@@ -102,80 +102,6 @@ impl Default for EncodedPrefixVarint {
         EncodedPrefixVarint {
             buf: [0u8; MAX_LEN],
             len: 0,
-        }
-    }
-}
-
-// XXX move to bytes, reexport in lib
-fn put_prefix_varint_slow<B: BufMut>(v: u64, buf: &mut B) -> usize {
-    if v <= MAX_VALUE[8] {
-        let len = v.prefix_varint_len();
-        buf.put_uint(v | TAG_PREFIX[len], len);
-        len
-    } else {
-        buf.put_u8(u8::MAX);
-        buf.put_u64(v);
-        9
-    }
-}
-
-pub trait PrefixVarIntBufMut {
-    fn put_prefix_varint<PV: PrefixVarInt>(&mut self, v: PV);
-}
-
-impl<Inner: BufMut> PrefixVarIntBufMut for Inner {
-    #[inline]
-    fn put_prefix_varint<PV: PrefixVarInt>(&mut self, v: PV) {
-        let raw = v.to_prefix_varint_raw();
-        if raw <= MAX_VALUE[1] {
-            self.put_u8(raw as u8);
-        } else if self.chunk_mut().len() >= MAX_LEN {
-            unsafe {
-                let len = encode_prefix_uvarint_slow(raw, self.chunk_mut().as_mut_ptr());
-                self.advance_mut(len);
-            }
-        } else {
-            put_prefix_varint_slow(raw, self);
-        }
-    }
-}
-
-fn get_prefix_varint_slow<B: Buf>(tag: u8, buf: &mut B) -> Result<u64, DecodeError> {
-    let rem = tag.leading_ones() as usize;
-    if rem > buf.remaining() {
-        buf.advance(buf.remaining());
-        Err(DecodeError::UnexpectedEob)
-    } else if rem < 8 {
-        let raw = (u64::from(tag) << (rem * 8)) | buf.get_uint(rem);
-        Ok(raw & MAX_VALUE[rem + 1])
-    } else {
-        Ok(buf.get_u64())
-    }
-}
-
-pub trait PrefixVarIntBuf {
-    fn get_prefix_varint<PV: PrefixVarInt>(&mut self) -> Result<PV, DecodeError>;
-}
-
-impl<Inner: Buf> PrefixVarIntBuf for Inner {
-    #[inline]
-    fn get_prefix_varint<PV: PrefixVarInt>(&mut self) -> Result<PV, DecodeError> {
-        if self.remaining() == 0 {
-            return Err(DecodeError::UnexpectedEob);
-        }
-
-        if self.chunk().len() >= MAX_LEN || self.remaining() == self.chunk().len() {
-            let (raw, len) = unsafe { decode_prefix_uvarint(self.chunk().as_ptr()) };
-            self.advance(len);
-            return PV::from_prefix_varint_raw(raw).ok_or(DecodeError::Overflow);
-        }
-
-        let tag = self.get_u8();
-        if tag <= MAX_1BYTE_TAG {
-            PV::from_prefix_varint_raw(tag.into()).ok_or(DecodeError::Overflow)
-        } else {
-            PV::from_prefix_varint_raw(get_prefix_varint_slow(tag, self)?)
-                .ok_or(DecodeError::Overflow)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,10 +234,8 @@ macro_rules! define_prefix_varint {
     };
 }
 
-define_prefix_varint!(u8, u64);
 define_prefix_varint!(u16, u64);
 define_prefix_varint!(u32, u64);
-define_prefix_varint!(i8, i64);
 define_prefix_varint!(i16, i64);
 define_prefix_varint!(i32, i64);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,17 +3,17 @@
 //! Unlike an [LEB128](https://en.wikipedia.org/wiki/LEB128)-style encoding scheme, this encoding
 //! uses a unary prefix code in the first byte of the value to indicate how many subsequent bytes
 //! need to be read followed by the big endian encoding of any remaining bytes. This improves
-//! coding speed compared to LEB128 by reducing the number of branches required to code longer
-//! values.
+//! coding speed compared to LEB128 by reducing the number of branches evaluated to code longer
+//! values, and allows those branches to be different to improve branch mis-prediction.
 //!
-//! `uvarint` methods code `u64` values, with values closer to zero producing smaller output.
-//! `varint` methods code `i64` values using a [Zigzag](https://en.wikipedia.org/wiki/Variable-length_quantity#Zigzag_encoding)
-//! encoding to ensure that small negative numbers produce small output.
+//! The `PrefixVarInt` trait is implemented for `u64`, `u32`, `u16`, `i64`, `i32`, and `i16`, with
+//! values closer to zero producing small output. Signed values are written using a [Zigzag](https://en.wikipedia.org/wiki/Variable-length_quantity#Zigzag_encoding)
+//! coding to ensure that small negative numbers produce small output.
 //!
-//! Coding methods are provided as extensions to the `bytes::{Buf,BufMut}` traits which are
-//! implemented for common in-memory byte stream types. Lower level methods that operate directly
-//! on pointers are also provided but come with caveats (may overread/overwrite).
+//! `PrefixVarInt` includes methods to code values directly to/from byte slices, but traits are
+//! provided to extend `bytes::{Buf,BufMut}`, and to handle these values in `std::io::{Write,Read}.
 //!
+//! XXX completely rewrite this example.
 //! ```
 //! use bytes::Buf;
 //! use prefix_uvarint::{PrefixVarIntBufMut, PrefixVarIntBuf};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,113 +33,17 @@
 mod bytes;
 pub(crate) mod core;
 mod io;
+mod raw;
 #[cfg(test)]
 mod tests;
 
 pub use crate::bytes::{PrefixVarIntBuf, PrefixVarIntBufMut};
-pub use crate::core::PrefixVarInt;
+pub use crate::core::{DecodeError, EncodedPrefixVarInt, PrefixVarInt};
 pub use crate::io::{PrefixVarIntRead, PrefixVarIntWrite};
 
-// XXX move to core, reexport in lib.
 /// Maximum number of bytes a single encoded uvarint will occupy.
 pub const MAX_LEN: usize = 9;
 
-// XXX move to core, reexport in lib.
-/// Errors that may occur during decoding.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum DecodeError {
-    /// Reached end-of-buffer unexpectedly.
-    ///
-    /// This may happen if you attempt to decode an empty buffer or if the buffer is too short to
-    /// contain the expected value.
-    UnexpectedEob,
-    /// The value read is larger than the destination type.
-    Overflow,
-}
-
-impl std::fmt::Display for DecodeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-impl std::error::Error for DecodeError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
-
-    fn description(&self) -> &str {
-        ""
-    }
-
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        None
-    }
-}
-
-/// A single encoded prefix varint value for with `PrefixVarInt.to_prefix_varint_bytes()`.
-/// XXX move to core, reexport in lib.
-pub struct EncodedPrefixVarint {
-    buf: [u8; MAX_LEN],
-    len: u8,
-}
-
-impl EncodedPrefixVarint {
-    fn new(v: u64) -> Self {
-        let mut enc = Self::default();
-        let len = unsafe { encode_prefix_uvarint(v, enc.buf.as_mut_ptr()) };
-        enc.len = len as u8;
-        enc
-    }
-
-    pub fn as_slice(&self) -> &[u8] {
-        &self.buf[..(self.len as usize)]
-    }
-}
-
-impl Default for EncodedPrefixVarint {
-    fn default() -> Self {
-        EncodedPrefixVarint {
-            buf: [0u8; MAX_LEN],
-            len: 0,
-        }
-    }
-}
-
-// XXX move to core
-/// Maps negative values to positive values, creating a sequence that alternates between negative
-/// and positive values. This makes the value more amenable to efficient prefix uvarint encoding.
-#[inline]
-pub(crate) fn zigzag_encode(v: i64) -> u64 {
-    ((v >> 63) ^ (v << 1)) as u64
-}
-
-// XXX move to core
-/// Inverts `zigzag_encode()`.
-#[inline]
-pub(crate) fn zigzag_decode(v: u64) -> i64 {
-    (v >> 1) as i64 ^ -(v as i64 & 1)
-}
-
-// XXX move to core.
-/// Return the number of bytes required to encode `v` in `[1,MAX_LEN]`.
-#[inline]
-pub fn prefix_uvarint_len(mut v: u64) -> usize {
-    // Mask off the top bit to cap bits_required to a maximum of 63.
-    // This avoids a branch to cap the maximum returned value of MAX_LEN.
-    v |= v >> 1;
-    v &= (1 << 63) - 1;
-    let bits_required = 64 - (v.leading_zeros() as usize);
-    ((bits_required.saturating_sub(1)) / 7) + 1
-}
-
-/// Return the number of bytes required to encode `v` in `[1,MAX_LEN]`.
-#[inline]
-pub fn prefix_varint_len(v: i64) -> usize {
-    prefix_uvarint_len(zigzag_encode(v))
-}
-
-// XXX move to core.
 /// Max value for an n-byte length.
 const MAX_VALUE: [u64; 10] = [
     0x0, // placeholder
@@ -154,7 +58,6 @@ const MAX_VALUE: [u64; 10] = [
     0xffffffffffffffff,
 ];
 
-// XXX move to core.
 /// Tag prefix value for an n-byte length to OR with the value.
 const TAG_PREFIX: [u64; 9] = [
     0x0, // placeholder
@@ -168,121 +71,4 @@ const TAG_PREFIX: [u64; 9] = [
     0xfe00000000000000,
 ];
 
-unsafe fn encode_prefix_uvarint_slow(v: u64, p: *mut u8) -> usize {
-    if v <= MAX_VALUE[2] {
-        let tv = (v | TAG_PREFIX[2]) as u16;
-        std::ptr::write_unaligned(p as *mut u16, tv.to_be());
-        2
-    } else if v <= MAX_VALUE[3] {
-        let tv = ((v | TAG_PREFIX[3]) << 8) as u32;
-        std::ptr::write_unaligned(p as *mut u32, tv.to_be());
-        3
-    } else if v <= MAX_VALUE[4] {
-        let tv = (v | TAG_PREFIX[4]) as u32;
-        std::ptr::write_unaligned(p as *mut u32, tv.to_be());
-        4
-    } else if v <= MAX_VALUE[5] {
-        let tv = (v | TAG_PREFIX[5]) << 24;
-        std::ptr::write_unaligned(p as *mut u64, tv.to_be());
-        5
-    } else if v <= MAX_VALUE[6] {
-        let tv = (v | TAG_PREFIX[6]) << 16;
-        std::ptr::write_unaligned(p as *mut u64, tv.to_be());
-        6
-    } else if v <= MAX_VALUE[7] {
-        let tv = (v | TAG_PREFIX[7]) << 8;
-        std::ptr::write_unaligned(p as *mut u64, tv.to_be());
-        7
-    } else if v <= MAX_VALUE[8] {
-        let tv = v | TAG_PREFIX[8];
-        std::ptr::write_unaligned(p as *mut u64, tv.to_be());
-        8
-    } else {
-        std::ptr::write(p, u8::MAX);
-        std::ptr::write_unaligned(p.add(1) as *mut u64, v.to_be());
-        9
-    }
-}
-
-/// Encodes `v` as a prefix uvarint to `p`.
-///
-/// This may write up to `MAX_LEN` bytes and may panic if fewer bytes are
-/// available.
-///
-/// # Safety
-///
-/// This method may overread/overwrite memory if `p` is not at least `MAX_LEN`
-/// bytes long. It is the caller's responsibility to ensure that `p` is valid
-/// for writes of `MAX_LEN` bytes.
-#[inline]
-pub unsafe fn encode_prefix_uvarint(v: u64, p: *mut u8) -> usize {
-    if v <= MAX_VALUE[1] {
-        std::ptr::write(p, v as u8);
-        1
-    } else {
-        encode_prefix_uvarint_slow(v, p)
-    }
-}
-
-pub(crate) unsafe fn decode_prefix_uvarint_slow(tag: u8, p: *const u8) -> (u64, usize) {
-    let (raw, len) = match tag.leading_ones() {
-        // NB: zero is handled by decode_prefix_uvarint().
-        1 => (
-            u64::from(u16::from_be(std::ptr::read_unaligned(p as *const u16))) & MAX_VALUE[2],
-            2,
-        ),
-        2 => (
-            u64::from(u32::from_be(std::ptr::read_unaligned(p as *const u32)) >> 8) & MAX_VALUE[3],
-            3,
-        ),
-        3 => (
-            u64::from(u32::from_be(std::ptr::read_unaligned(p as *const u32))) & MAX_VALUE[4],
-            4,
-        ),
-        4 => (
-            (u64::from_be(std::ptr::read_unaligned(p as *const u64)) >> 24) & MAX_VALUE[5],
-            5,
-        ),
-        5 => (
-            (u64::from_be(std::ptr::read_unaligned(p as *const u64)) >> 16) & MAX_VALUE[6],
-            6,
-        ),
-        6 => (
-            (u64::from_be(std::ptr::read_unaligned(p as *const u64)) >> 8) & MAX_VALUE[7],
-            7,
-        ),
-        7 => (
-            u64::from_be(std::ptr::read_unaligned(p as *const u64)) & MAX_VALUE[8],
-            8,
-        ),
-        // NB: this is a catch-all but the maximum possible value for tag.leading_ones() is 8.
-        _ => (
-            u64::from_be(std::ptr::read_unaligned(p.add(1) as *const u64)),
-            9,
-        ),
-    };
-    (raw, len)
-}
-
 pub(crate) const MAX_1BYTE_TAG: u8 = MAX_VALUE[1] as u8;
-
-/// Decodes a prefix uvarint value from `p`, returning the value and the number
-/// of bytes consumed.
-///
-/// This function may read up to `MAX_LEN` bytes from `p` and may panic if fewer
-/// bytes are available.
-///
-/// # Safety
-///
-/// This method may overread memory if `p` is not at least `MAX_LEN` bytes long.
-/// It is the caller's responsibility to ensure that `p` is valid for reads of
-/// `MAX_LEN` bytes.
-#[inline]
-pub unsafe fn decode_prefix_uvarint(p: *const u8) -> (u64, usize) {
-    let tag = std::ptr::read(p);
-    if tag <= MAX_1BYTE_TAG {
-        (tag.into(), 1)
-    } else {
-        decode_prefix_uvarint_slow(tag, p)
-    }
-}

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,0 +1,137 @@
+//! Routines for working with raw (u64) prefix varints.
+//!
+//! Other types should be shuffled to/from raw values using the `core::Int` trait.
+
+use crate::{MAX_1BYTE_TAG, MAX_VALUE, TAG_PREFIX};
+
+/// Return the number of bytes required to encode `v` in `[1,MAX_LEN]`.
+#[inline]
+pub(crate) fn len(mut v: u64) -> usize {
+    // Mask off the top bit to cap bits_required to a maximum of 63.
+    // This avoids a branch to cap the maximum returned value of MAX_LEN.
+    v |= v >> 1;
+    v &= (1 << 63) - 1;
+    let bits_required = 64 - (v.leading_zeros() as usize);
+    ((bits_required.saturating_sub(1)) / 7) + 1
+}
+
+/// Encodes a raw value that produce multiple bytes of output.
+///
+/// This may generate a substantial amount of code so it is not inlined.
+///
+/// # Safety
+///
+/// This assumes that bytes `p..=(p + MAX_LEN)` may be written to.
+pub(crate) unsafe fn encode_multibyte(v: u64, p: *mut u8) -> usize {
+    if v <= MAX_VALUE[2] {
+        let tv = (v | TAG_PREFIX[2]) as u16;
+        std::ptr::write_unaligned(p as *mut u16, tv.to_be());
+        2
+    } else if v <= MAX_VALUE[3] {
+        let tv = ((v | TAG_PREFIX[3]) << 8) as u32;
+        std::ptr::write_unaligned(p as *mut u32, tv.to_be());
+        3
+    } else if v <= MAX_VALUE[4] {
+        let tv = (v | TAG_PREFIX[4]) as u32;
+        std::ptr::write_unaligned(p as *mut u32, tv.to_be());
+        4
+    } else if v <= MAX_VALUE[5] {
+        let tv = (v | TAG_PREFIX[5]) << 24;
+        std::ptr::write_unaligned(p as *mut u64, tv.to_be());
+        5
+    } else if v <= MAX_VALUE[6] {
+        let tv = (v | TAG_PREFIX[6]) << 16;
+        std::ptr::write_unaligned(p as *mut u64, tv.to_be());
+        6
+    } else if v <= MAX_VALUE[7] {
+        let tv = (v | TAG_PREFIX[7]) << 8;
+        std::ptr::write_unaligned(p as *mut u64, tv.to_be());
+        7
+    } else if v <= MAX_VALUE[8] {
+        let tv = v | TAG_PREFIX[8];
+        std::ptr::write_unaligned(p as *mut u64, tv.to_be());
+        8
+    } else {
+        std::ptr::write(p, u8::MAX);
+        std::ptr::write_unaligned(p.add(1) as *mut u64, v.to_be());
+        9
+    }
+}
+
+/// Encodes a raw value as prefix uvarint to `p`.
+///
+/// # Safety
+///
+/// This assumes that bytes `p..=(p + MAX_LEN)` may be written to.
+#[inline]
+pub unsafe fn encode(v: u64, p: *mut u8) -> usize {
+    if v <= MAX_VALUE[1] {
+        std::ptr::write(p, v as u8);
+        1
+    } else {
+        encode_multibyte(v, p)
+    }
+}
+
+/// Decodes a prefix uvarint value from `p`, returning the value and the number
+/// of bytes consumed.
+///
+/// `p` points to the byte that produced the value `tag`.
+///
+/// # Safety
+///
+/// This assumes that bytes `p..=(p + MAX_LEN)` may be read from.
+pub(crate) unsafe fn decode_multibyte(tag: u8, p: *const u8) -> (u64, usize) {
+    let (raw, len) = match tag.leading_ones() {
+        // NB: zero is handled by decode_prefix_uvarint().
+        1 => (
+            u64::from(u16::from_be(std::ptr::read_unaligned(p as *const u16))) & MAX_VALUE[2],
+            2,
+        ),
+        2 => (
+            u64::from(u32::from_be(std::ptr::read_unaligned(p as *const u32)) >> 8) & MAX_VALUE[3],
+            3,
+        ),
+        3 => (
+            u64::from(u32::from_be(std::ptr::read_unaligned(p as *const u32))) & MAX_VALUE[4],
+            4,
+        ),
+        4 => (
+            (u64::from_be(std::ptr::read_unaligned(p as *const u64)) >> 24) & MAX_VALUE[5],
+            5,
+        ),
+        5 => (
+            (u64::from_be(std::ptr::read_unaligned(p as *const u64)) >> 16) & MAX_VALUE[6],
+            6,
+        ),
+        6 => (
+            (u64::from_be(std::ptr::read_unaligned(p as *const u64)) >> 8) & MAX_VALUE[7],
+            7,
+        ),
+        7 => (
+            u64::from_be(std::ptr::read_unaligned(p as *const u64)) & MAX_VALUE[8],
+            8,
+        ),
+        // NB: this is a catch-all but the maximum possible value for tag.leading_ones() is 8.
+        _ => (
+            u64::from_be(std::ptr::read_unaligned(p.add(1) as *const u64)),
+            9,
+        ),
+    };
+    (raw, len)
+}
+
+/// Decode a prefix uvarint value from `p`, returning the raw value and number of bytes consumed.
+///
+/// # Safety
+///
+/// This assumes that bytes `p..=(p + MAX_LEN)` may be read from.
+#[inline]
+pub unsafe fn decode(p: *const u8) -> (u64, usize) {
+    let tag = std::ptr::read(p);
+    if tag <= MAX_1BYTE_TAG {
+        (tag.into(), 1)
+    } else {
+        decode_multibyte(tag, p)
+    }
+}

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -4,8 +4,8 @@
 
 const fn len_slow(v: u64) -> usize {
     if v < (1 << 63) {
-        // Dividing by 7 triggers an optimization that yield a multiply instruction plus multiple
-        // shifts and masks to produce the value and this is slower than the encode path.
+        // Dividing by 7 triggers an optimization that yields a multiply instruction plus multiple
+        // shifts and masks to produce the length and this is slower than the encode path.
         (70 - (v | 1).leading_zeros() as usize) / 7
     } else {
         9
@@ -38,7 +38,7 @@ const fn tag_prefix(len: usize) -> u64 {
 
 /// Returns the maximum value for a given byte length. Useful for masking out tag bits.
 #[inline(always)]
-const fn max_value(len: usize) -> u64 {
+pub(crate) const fn max_value(len: usize) -> u64 {
     if len >= 9 {
         u64::MAX
     } else {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -42,7 +42,7 @@ const RANDOM_TEST_LEN: usize = 4096;
 
 mod raw {
     use super::PrefixVarIntBounds;
-    use crate::{raw, MAX_LEN};
+    use crate::{raw, PrefixVarInt, MAX_LEN};
 
     #[test]
     fn boundary_coding() {
@@ -52,10 +52,10 @@ mod raw {
             .enumerate()
             .map(|(i, x)| (i + 1, x))
         {
-            assert_eq!(raw::len(min), len, "{}", min);
+            assert_eq!(min.prefix_varint_len(), len, "{}", min);
             assert_eq!(unsafe { raw::encode(min, buf.as_mut_ptr()) }, len);
             assert_eq!(unsafe { raw::decode(buf.as_ptr()) }, (min, len));
-            assert_eq!(raw::len(max), len, "{}", max);
+            assert_eq!(max.prefix_varint_len(), len, "{}", max);
             assert_eq!(unsafe { raw::encode(max, buf.as_mut_ptr()) }, len);
             assert_eq!(unsafe { raw::decode(buf.as_ptr()) }, (max, len));
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -21,7 +21,12 @@ impl PrefixVarIntBounds for i64 {
     fn prefix_varint_bounds() -> Vec<(Self, Self)> {
         u64::prefix_varint_bounds()
             .into_iter()
-            .map(|(_, max)| (crate::zigzag_decode(max), crate::zigzag_decode(max - 1)))
+            .map(|(_, max)| {
+                (
+                    crate::core::zigzag_decode(max),
+                    crate::core::zigzag_decode(max - 1),
+                )
+            })
             .collect()
     }
 }
@@ -37,7 +42,7 @@ const RANDOM_TEST_LEN: usize = 4096;
 
 mod raw {
     use super::PrefixVarIntBounds;
-    use crate::{decode_prefix_uvarint, encode_prefix_uvarint, prefix_uvarint_len, MAX_LEN};
+    use crate::{raw, MAX_LEN};
 
     #[test]
     fn boundary_coding() {
@@ -47,12 +52,12 @@ mod raw {
             .enumerate()
             .map(|(i, x)| (i + 1, x))
         {
-            assert_eq!(prefix_uvarint_len(min), len, "{}", min);
-            assert_eq!(unsafe { encode_prefix_uvarint(min, buf.as_mut_ptr()) }, len);
-            assert_eq!(unsafe { decode_prefix_uvarint(buf.as_ptr()) }, (min, len));
-            assert_eq!(prefix_uvarint_len(max), len, "{}", max);
-            assert_eq!(unsafe { encode_prefix_uvarint(max, buf.as_mut_ptr()) }, len);
-            assert_eq!(unsafe { decode_prefix_uvarint(buf.as_ptr()) }, (max, len));
+            assert_eq!(raw::len(min), len, "{}", min);
+            assert_eq!(unsafe { raw::encode(min, buf.as_mut_ptr()) }, len);
+            assert_eq!(unsafe { raw::decode(buf.as_ptr()) }, (min, len));
+            assert_eq!(raw::len(max), len, "{}", max);
+            assert_eq!(unsafe { raw::encode(max, buf.as_mut_ptr()) }, len);
+            assert_eq!(unsafe { raw::decode(buf.as_ptr()) }, (max, len));
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,16 +2,28 @@ use rand::distributions::uniform::SampleUniform;
 use rand::distributions::Uniform;
 use rand::prelude::*;
 
-fn bounds_u64() -> impl Iterator<Item = (u64, u64)> {
-    crate::MAX_VALUE
-        .iter()
-        .copied()
-        .zip(crate::MAX_VALUE.iter().skip(1).copied())
-        .map(|(min, max)| if min > 0 { (min + 1, max) } else { (min, max) })
+trait PrefixVarIntBounds: Sized {
+    fn prefix_varint_bounds() -> Vec<(Self, Self)>;
 }
 
-fn bounds_i64() -> impl Iterator<Item = (i64, i64)> {
-    bounds_u64().map(|(_, max)| (crate::zigzag_decode(max), crate::zigzag_decode(max - 1)))
+impl PrefixVarIntBounds for u64 {
+    fn prefix_varint_bounds() -> Vec<(Self, Self)> {
+        crate::MAX_VALUE
+            .iter()
+            .copied()
+            .zip(crate::MAX_VALUE.iter().skip(1).copied())
+            .map(|(min, max)| if min > 0 { (min + 1, max) } else { (min, max) })
+            .collect()
+    }
+}
+
+impl PrefixVarIntBounds for i64 {
+    fn prefix_varint_bounds() -> Vec<(Self, Self)> {
+        u64::prefix_varint_bounds()
+            .into_iter()
+            .map(|(_, max)| (crate::zigzag_decode(max), crate::zigzag_decode(max - 1)))
+            .collect()
+    }
 }
 
 fn generate_array<V: SampleUniform + Copy>(len: usize, min: V, max: V) -> Vec<V> {
@@ -24,13 +36,17 @@ fn generate_array<V: SampleUniform + Copy>(len: usize, min: V, max: V) -> Vec<V>
 const RANDOM_TEST_LEN: usize = 4096;
 
 mod raw {
-    use super::bounds_u64;
+    use super::PrefixVarIntBounds;
     use crate::{decode_prefix_uvarint, encode_prefix_uvarint, prefix_uvarint_len, MAX_LEN};
 
     #[test]
     fn boundary_coding() {
         let mut buf = [0u8; MAX_LEN];
-        for (len, (min, max)) in bounds_u64().enumerate().map(|(i, x)| (i + 1, x)) {
+        for (len, (min, max)) in u64::prefix_varint_bounds()
+            .into_iter()
+            .enumerate()
+            .map(|(i, x)| (i + 1, x))
+        {
             assert_eq!(prefix_uvarint_len(min), len, "{}", min);
             assert_eq!(unsafe { encode_prefix_uvarint(min, buf.as_mut_ptr()) }, len);
             assert_eq!(unsafe { decode_prefix_uvarint(buf.as_ptr()) }, (min, len));
@@ -42,24 +58,24 @@ mod raw {
 }
 
 mod buf {
-    use super::{bounds_i64, bounds_u64, generate_array, RANDOM_TEST_LEN};
-    use crate::{VarintBuf, VarintBufMut, MAX_VALUE, TAG_PREFIX};
+    use super::{generate_array, PrefixVarIntBounds, RANDOM_TEST_LEN};
+    use crate::{DecodeError, PrefixVarInt, MAX_VALUE, TAG_PREFIX};
 
     macro_rules! test_random_buf_put_get {
-        ($name:ident, $bounds:ident, $put:ident, $get:ident) => {
+        ($int:ty, $name:ident) => {
             #[test]
             fn $name() {
-                for (min, max) in $bounds() {
+                for (min, max) in <$int>::prefix_varint_bounds() {
                     let input_values = generate_array(RANDOM_TEST_LEN, min, max);
                     let mut buf_mut: Vec<u8> = Vec::new();
                     for v in input_values.iter() {
-                        buf_mut.$put(*v);
+                        v.encode_varint(&mut buf_mut);
                     }
 
                     let mut output_values = Vec::new();
                     let mut buf = buf_mut.as_slice();
                     for _ in 0..input_values.len() {
-                        output_values.push(buf.$get().unwrap());
+                        output_values.push(<$int>::decode_varint(&mut buf).unwrap());
                     }
 
                     assert_eq!(input_values, output_values, "{}..{}", min, max);
@@ -68,24 +84,27 @@ mod buf {
         };
     }
 
-    test_random_buf_put_get!(
-        random_u64,
-        bounds_u64,
-        put_prefix_uvarint,
-        get_prefix_uvarint
-    );
-    test_random_buf_put_get!(random_i64, bounds_i64, put_prefix_varint, get_prefix_varint);
+    test_random_buf_put_get!(u64, random_u64);
+    test_random_buf_put_get!(i64, random_i64);
 
     #[test]
     fn decode_empty_fail() {
-        assert_eq!([].as_slice().get_prefix_uvarint(), None);
+        assert_eq!(
+            u64::decode_varint(&mut [].as_slice()),
+            Err(DecodeError::UnexpectedEob)
+        );
     }
 
     #[test]
     fn decode_tag_only_fail() {
         let mut tag = u8::MAX;
         while tag != 0 {
-            assert_eq!([tag].as_slice().get_prefix_uvarint(), None, "{:#b}", tag);
+            assert_eq!(
+                u64::decode_varint(&mut [tag].as_slice()),
+                Err(DecodeError::UnexpectedEob),
+                "{:#b}",
+                tag
+            );
             tag <<= 1;
         }
     }
@@ -94,10 +113,25 @@ mod buf {
     fn decode_truncated() {
         for v in MAX_VALUE.iter().skip(1) {
             let mut buf = Vec::new();
-            buf.put_prefix_uvarint(*v);
+            v.encode_varint(&mut buf);
             let mut trunc = &buf[0..(buf.len() - 1)];
-            assert_eq!(trunc.get_prefix_uvarint(), None, "{}", *v);
+            assert_eq!(
+                u64::decode_varint(&mut trunc),
+                Err(DecodeError::UnexpectedEob),
+                "{}",
+                *v
+            );
         }
+    }
+
+    #[test]
+    fn decode_overflow() {
+        let mut buf = Vec::new();
+        u64::MAX.encode_varint(&mut buf);
+        assert_eq!(
+            u32::decode_varint(&mut buf.as_slice()),
+            Err(DecodeError::Overflow)
+        );
     }
 
     #[test]
@@ -111,16 +145,16 @@ mod buf {
 }
 
 mod io {
-    use super::{bounds_i64, bounds_u64, generate_array, RANDOM_TEST_LEN};
+    use super::{generate_array, PrefixVarIntBounds, RANDOM_TEST_LEN};
     use crate::io::VarintWrite;
 
     macro_rules! test_random_io_write_read {
-        ($name:ident, $reader:ident, $bounds:ident, $write:ident, $read:ident) => {
+        ($name:ident, $int:ty, $reader:ident, $write:ident, $read:ident) => {
             #[test]
             fn $name() {
                 use crate::io::$reader;
 
-                for (min, max) in $bounds() {
+                for (min, max) in <$int>::prefix_varint_bounds() {
                     let input_values = generate_array(RANDOM_TEST_LEN, min, max);
                     let mut write: Vec<u8> = Vec::new();
                     for v in input_values.iter() {
@@ -140,29 +174,29 @@ mod io {
     }
     test_random_io_write_read!(
         random_read_u64,
+        u64,
         VarintRead,
-        bounds_u64,
         write_prefix_uvarint,
         read_prefix_uvarint
     );
     test_random_io_write_read!(
         random_read_i64,
+        i64,
         VarintRead,
-        bounds_i64,
         write_prefix_varint,
         read_prefix_varint
     );
     test_random_io_write_read!(
         random_bufread_u64,
+        u64,
         VarintBufRead,
-        bounds_u64,
         write_prefix_uvarint,
         read_prefix_uvarint
     );
     test_random_io_write_read!(
         random_bufread_i64,
+        i64,
         VarintBufRead,
-        bounds_i64,
         write_prefix_varint,
         read_prefix_varint
     );

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -146,24 +146,22 @@ mod buf {
 
 mod io {
     use super::{generate_array, PrefixVarIntBounds, RANDOM_TEST_LEN};
-    use crate::io::VarintWrite;
+    use crate::io::{PrefixVarIntRead, PrefixVarIntWrite};
 
     macro_rules! test_random_io_write_read {
-        ($name:ident, $int:ty, $reader:ident, $write:ident, $read:ident) => {
+        ($name:ident, $int:ty) => {
             #[test]
             fn $name() {
-                use crate::io::$reader;
-
                 for (min, max) in <$int>::prefix_varint_bounds() {
                     let input_values = generate_array(RANDOM_TEST_LEN, min, max);
-                    let mut write: Vec<u8> = Vec::new();
+                    let mut writer: Vec<u8> = Vec::new();
                     for v in input_values.iter() {
-                        write.$write(*v).unwrap();
+                        writer.write_prefix_varint(*v).unwrap();
                     }
 
                     let mut output_values = Vec::new();
-                    let mut read = write.as_slice();
-                    while let Ok(v) = read.$read() {
+                    let mut reader = writer.as_slice();
+                    while let Ok(v) = reader.read_prefix_varint::<$int>() {
                         output_values.push(v);
                     }
 
@@ -172,32 +170,6 @@ mod io {
             }
         };
     }
-    test_random_io_write_read!(
-        random_read_u64,
-        u64,
-        VarintRead,
-        write_prefix_uvarint,
-        read_prefix_uvarint
-    );
-    test_random_io_write_read!(
-        random_read_i64,
-        i64,
-        VarintRead,
-        write_prefix_varint,
-        read_prefix_varint
-    );
-    test_random_io_write_read!(
-        random_bufread_u64,
-        u64,
-        VarintBufRead,
-        write_prefix_uvarint,
-        read_prefix_uvarint
-    );
-    test_random_io_write_read!(
-        random_bufread_i64,
-        i64,
-        VarintBufRead,
-        write_prefix_varint,
-        read_prefix_varint
-    );
+    test_random_io_write_read!(random_read_u64, u64);
+    test_random_io_write_read!(random_read_i64, i64);
 }


### PR DESCRIPTION
Introduce a `PrefixVarInt` trait that applies to all integers sized 16-64 bytes with stand-alone encode and decode methods.
This is not implemented for `usize` or `isize` as those are platform dependent and callers should use a fixed-size integer
for correctness.

Use the new trait to avoid duplicating methods for unsigned/signed in interfaces, so this works out roughly like an overload
although turbofish may be required during decoding in some cases. `Buf` and `BufMut` extensions are retained, but the
`io` support has been turned into stand-alone methods as extending the interface doesn't make as much sense there -- the
interface exclusively supports ~byte slice.

This change features substantial performance improvements to all methods, in particular handling of short (single byte)
values is much faster. Computing the encoded length of an integer is also much faster now.