### PR TITLE
Fix invalid decoding

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "prefix_uvarint-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.prefix_uvarint]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "encode_u32"
+path = "fuzz_targets/encode_u32.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "decode_u32"
+path = "fuzz_targets/decode_u32.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "encode_u64"
+path = "fuzz_targets/encode_u64.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "decode_u64"
+path = "fuzz_targets/decode_u64.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/decode_u32.rs
+++ b/fuzz/fuzz_targets/decode_u32.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use prefix_uvarint::PrefixVarIntBuf;
+
+fuzz_target!(|data: &[u8]| {
+    // attempts to decode all the data as a u32 error are ok, panics are not
+    let mut src = data;
+    while !src.is_empty() {
+        if let Err(_) = src.get_prefix_varint::<u32>() {
+            break;
+        }
+    }
+});

--- a/fuzz/fuzz_targets/decode_u64.rs
+++ b/fuzz/fuzz_targets/decode_u64.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use prefix_uvarint::PrefixVarIntBuf;
+
+fuzz_target!(|data: &[u8]| {
+    // attempts to decode all the data as a u64 error are ok, panics are not
+    let mut src = data;
+    while !src.is_empty() {
+        if let Err(_) = src.get_prefix_varint::<u64>() {
+            break;
+        }
+    }
+});

--- a/fuzz/fuzz_targets/encode_u32.rs
+++ b/fuzz/fuzz_targets/encode_u32.rs
@@ -1,0 +1,22 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use prefix_uvarint::{PrefixVarIntBuf, PrefixVarIntBufMut};
+
+fuzz_target!(|data: &[u8]| {
+    let mut dst = vec![];
+    for chunk in data.chunks_exact(4) {
+        let mut buf = [0; 4];
+        buf.copy_from_slice(chunk);
+        let n = u32::from_le_bytes(buf);
+        dst.put_prefix_varint(n);
+    }
+
+    let mut src = &dst[..];
+    for chunk in data.chunks_exact(4) {
+        let mut buf = [0; 4];
+        buf.copy_from_slice(chunk);
+        let n = u32::from_le_bytes(buf);
+        assert_eq!(src.get_prefix_varint::<u32>().unwrap(), n);
+    }
+});

--- a/fuzz/fuzz_targets/encode_u64.rs
+++ b/fuzz/fuzz_targets/encode_u64.rs
@@ -1,0 +1,22 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use prefix_uvarint::{PrefixVarIntBuf, PrefixVarIntBufMut};
+
+fuzz_target!(|data: &[u8]| {
+    let mut dst = vec![];
+    for chunk in data.chunks_exact(8) {
+        let mut buf = [0; 8];
+        buf.copy_from_slice(chunk);
+        let n = u64::from_le_bytes(buf);
+        dst.put_prefix_varint(n);
+    }
+
+    let mut src = &dst[..];
+    for chunk in data.chunks_exact(8) {
+        let mut buf = [0; 8];
+        buf.copy_from_slice(chunk);
+        let n = u64::from_le_bytes(buf);
+        assert_eq!(src.get_prefix_varint::<u64>().unwrap(), n);
+    }
+});

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -63,7 +63,10 @@ impl<Inner: Buf> PrefixVarIntBuf for Inner {
             return Err(DecodeError::UnexpectedEob);
         }
 
-        if self.chunk().len() >= MAX_LEN || self.remaining() == self.chunk().len() {
+        if self.chunk().len() >= MAX_LEN {
+            // SAFETY: we checked that the buffer is at least MAX_LEN bytes long
+            // so we can always safely call decode_multibyte and never read
+            // uninitialized memory.
             let (raw, len) = unsafe { raw::decode(self.chunk().as_ptr()) };
             self.advance(len);
             return PV::from_prefix_varint_raw(raw).ok_or(DecodeError::Overflow);

--- a/tests/fuzz.rs
+++ b/tests/fuzz.rs
@@ -1,0 +1,17 @@
+use prefix_uvarint::PrefixVarIntBuf;
+
+#[test]
+fn does_not_read_out_of_bounds() {
+    // Run with RUSTFLAGS=-Zsanitizer=address cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu --test fuzz
+    let decode_data = [240u8, 175, 59, 43, 0];
+    let mut buf = decode_data.as_slice();
+    let v = buf.get_prefix_varint::<u32>().unwrap();
+    assert_eq!(v, 2939890432);
+}
+
+#[test]
+fn returns_error_for_small_data() {
+    let decode_data = [171u8];
+    let mut buf = decode_data.as_slice();
+    assert!(buf.get_prefix_varint::<u32>().is_err());
+}


### PR DESCRIPTION
- Add fuzzing
- remove out of bounds memory read
- handle invalid data 

fixes #8 #7 

I think `|| self.remaining() == self.chunk().len()`  statement was trying to make the assumption we are in the last block so we could use the ptr reads but that incorrectly let other cases through.