### PR TITLE
Unroll multibyte encode and decode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prefix_uvarint"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Trevor McCulloch <mccullocht@gmail.com>"]
 edition = "2021"
 description = "Prefix based variable length integer coding."

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -69,13 +69,26 @@ pub(crate) unsafe fn encode_multibyte(v: u64, p: *mut u8) -> usize {
         let tagged = (tag_prefix | v) as u32;
         std::ptr::write_unaligned(p as *mut u32, tagged.to_be());
         4
-    } else if v <= max_value(8) {
-        // This is a shortcut for len() where we assume the result is in 1..=8 (true here)
-        let len = (70 - v.leading_zeros()) as usize / 7;
-        let tag_prefix = tag_prefix(len);
-        let tagged = tag_prefix | (v << (64 - (len * 8)));
+    } else if v <= max_value(5) {
+        let tag_prefix = tag_prefix(5);
+        let tagged = tag_prefix | (v << 24);
         std::ptr::write_unaligned(p as *mut u64, tagged.to_be());
-        len
+        5
+    } else if v <= max_value(6) {
+        let tag_prefix = tag_prefix(6);
+        let tagged = tag_prefix | (v << 16);
+        std::ptr::write_unaligned(p as *mut u64, tagged.to_be());
+        6
+    } else if v <= max_value(7) {
+        let tag_prefix = tag_prefix(7);
+        let tagged = tag_prefix | (v << 8);
+        std::ptr::write_unaligned(p as *mut u64, tagged.to_be());
+        7
+    } else if v <= max_value(8) {
+        let tag_prefix = tag_prefix(8);
+        let tagged = tag_prefix | v;
+        std::ptr::write_unaligned(p as *mut u64, tagged.to_be());
+        8
     } else {
         std::ptr::write(p, u8::MAX);
         std::ptr::write_unaligned(p.add(1) as *mut u64, v.to_be());

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -122,13 +122,25 @@ pub(crate) unsafe fn decode_multibyte(tag: u8, p: *const u8) -> (u64, usize) {
             u64::from(u32::from_be(std::ptr::read_unaligned(p as *const u32))) & max_value(4),
             4,
         )
-    } else if tag < 0b11111111 {
-        let len = tag.leading_ones() as usize + 1;
-        let shift = (8 - len) * 8;
-        let mask = !(u64::MAX << (len * 7));
+    } else if tag < 0b11111000 {
         (
-            (u64::from_be(std::ptr::read_unaligned(p as *const u64)) >> shift) & mask,
-            len,
+            u64::from_be(std::ptr::read_unaligned(p as *const u64)) >> 24 & max_value(5),
+            5,
+        )
+    } else if tag < 0b11111100 {
+        (
+            u64::from_be(std::ptr::read_unaligned(p as *const u64)) >> 16 & max_value(6),
+            6,
+        )
+    } else if tag < 0b11111110 {
+        (
+            u64::from_be(std::ptr::read_unaligned(p as *const u64)) >> 8 & max_value(7),
+            7,
+        )
+    } else if tag < 0b11111111 {
+        (
+            u64::from_be(std::ptr::read_unaligned(p as *const u64)) & max_value(8),
+            8,
         )
     } else {
         (


### PR DESCRIPTION
Was doing some investigating into why 5,6,7,8 byte encode decode was so much slower. Saw a couple things.
- it computed the lens which means shifts were not compile time known
- division (which i hope would get replaced with optimization)
- used `leading_ones()` for decoding which is a few extra instructions, but also could be capturing by the if statement. That alone accounted for 18% of total decode time on my machine.

I encourage you to run the benchmarks yourself and see if I haven't made a mistake. Tests pass, fuzzing passes.

## Benchmark Results

This change should only really affect 5,6,7,8 byte values.

My machine is a amd 3900x

- Encoding is 70-100% faster
  on my machine. (amd 3900x).

- Decoding is 50-70% faster

### reading current

|         | `prefix_varint` current    |
| :------ | :------------------------- |
| **`1`** | `671.90 ns` (✅ **1.00x**) |
| **`2`** | `923.95 ns` (✅ **1.00x**) |
| **`3`** | `1.33 us` (✅ **1.00x**)   |
| **`4`** | `1.55 us` (✅ **1.00x**)   |
| **`5`** | `3.85 us` (✅ **1.00x**)   |
| **`6`** | `3.88 us` (✅ **1.00x**)   |
| **`7`** | `3.84 us` (✅ **1.00x**)   |
| **`8`** | `3.89 us` (✅ **1.00x**)   |
| **`9`** | `1.74 us` (✅ **1.00x**)   |

### reading unrolled

|         | `prefix_varint` unrolled   |
| :------ | :------------------------- |
| **`1`** | `662.38 ns` (✅ **1.00x**) |
| **`2`** | `1.13 us` (✅ **1.00x**)   |
| **`3`** | `1.10 us` (✅ **1.00x**)   |
| **`4`** | `1.53 us` (✅ **1.00x**)   |
| **`5`** | `1.79 us` (✅ **1.00x**)   |
| **`6`** | `2.01 us` (✅ **1.00x**)   |
| **`7`** | `2.24 us` (✅ **1.00x**)   |
| **`8`** | `2.25 us` (✅ **1.00x**)   |
| **`9`** | `2.45 us` (✅ **1.00x**)   |

---

### writing current

|         | `prefix_varint`            |
| :------ | :------------------------- |
| **`1`** | `928.60 ns` (✅ **1.00x**) |
| **`2`** | `1.47 us` (✅ **1.00x**)   |
| **`3`** | `1.58 us` (✅ **1.00x**)   |
| **`4`** | `1.63 us` (✅ **1.00x**)   |
| **`5`** | `3.54 us` (✅ **1.00x**)   |
| **`6`** | `3.51 us` (✅ **1.00x**)   |
| **`7`** | `3.55 us` (✅ **1.00x**)   |
| **`8`** | `3.52 us` (✅ **1.00x**)   |
| **`9`** | `1.79 us` (✅ **1.00x**)   |

### writing unrolled

|         | `prefix_varint`            |
| :------ | :------------------------- |
| **`1`** | `908.82 ns` (✅ **1.00x**) |
| **`2`** | `1.45 us` (✅ **1.00x**)   |
| **`3`** | `1.37 us` (✅ **1.00x**)   |
| **`4`** | `1.48 us` (✅ **1.00x**)   |
| **`5`** | `2.03 us` (✅ **1.00x**)   |
| **`6`** | `2.01 us` (✅ **1.00x**)   |
| **`7`** | `2.24 us` (✅ **1.00x**)   |
| **`8`** | `2.41 us` (✅ **1.00x**)   |
| **`9`** | `2.45 us` (✅ **1.00x**)   |
