### PR TITLE
Change write to return number of bytes written

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prefix_uvarint"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Trevor McCulloch <mccullocht@gmail.com>"]
 edition = "2021"
 description = "Prefix based variable length integer coding."

--- a/src/core.rs
+++ b/src/core.rs
@@ -109,7 +109,7 @@ impl EncodedPrefixVarInt {
     }
 
     pub fn as_slice(&self) -> &[u8] {
-        &self.buf[..(self.len as usize)]
+        &self.buf[..self.len()]
     }
 
     /// Returns the number of bytes used to encode the value.

--- a/src/core.rs
+++ b/src/core.rs
@@ -100,6 +100,7 @@ pub struct EncodedPrefixVarInt {
     len: u8,
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl EncodedPrefixVarInt {
     fn new(v: u64) -> Self {
         let mut enc = Self::default();

--- a/src/core.rs
+++ b/src/core.rs
@@ -111,6 +111,11 @@ impl EncodedPrefixVarInt {
     pub fn as_slice(&self) -> &[u8] {
         &self.buf[..(self.len as usize)]
     }
+
+    /// Returns the number of bytes used to encode the value.
+    pub fn len(&self) -> usize {
+        self.len as usize
+    }
 }
 
 impl Default for EncodedPrefixVarInt {

--- a/src/io.rs
+++ b/src/io.rs
@@ -13,10 +13,13 @@ impl From<DecodeError> for Error {
     }
 }
 
-/// Prefix varint code a value and write it to `w`.
+/// Prefix varint code a value and write it to `w`. Returns the number of bytes
+/// written.
 #[inline]
-pub fn write_prefix_varint<PV: PrefixVarInt>(v: PV, w: &mut impl Write) -> Result<()> {
-    w.write_all(v.to_prefix_varint_bytes().as_slice())
+pub fn write_prefix_varint<PV: PrefixVarInt>(v: PV, w: &mut impl Write) -> Result<usize> {
+    let v = v.to_prefix_varint_bytes();
+    w.write_all(v.as_slice())?;
+    Ok(v.len())
 }
 
 /// Read and decode a prefix varint value from `r`.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -186,6 +186,7 @@ mod buf {
 
 mod io {
     use super::{generate_array, PrefixVarIntBounds, RANDOM_TEST_LEN};
+    use crate::core::PrefixVarInt;
     use crate::io::{read_prefix_varint, read_prefix_varint_buf, write_prefix_varint};
 
     macro_rules! test_random_io_write_read {
@@ -196,7 +197,8 @@ mod io {
                     let input_values = generate_array(RANDOM_TEST_LEN, min, max);
                     let mut writer: Vec<u8> = Vec::new();
                     for v in input_values.iter() {
-                        write_prefix_varint(*v, &mut writer).unwrap();
+                        let num_bytes = write_prefix_varint(*v, &mut writer).unwrap();
+                        assert_eq!(num_bytes, (*v).prefix_varint_len());
                     }
 
                     let mut output_values = Vec::new();


### PR DESCRIPTION
The write interface usually returns the number of bytes written, however writeall doesn't because its assumed you know the sizes. However since the writeall was inside of the write it did not conform to the usual interface of returning bytes written. 

This changes adds returning number of bytes from a write call which is useful for encoding. 

Minor version bumped to 0.5.1