### PR TITLE
Rework iterator to be more versitile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prefix_uvarint"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Trevor McCulloch <mccullocht@gmail.com>"]
 edition = "2021"
 description = "Prefix based variable length integer coding."

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -33,8 +33,20 @@ test = false
 doc = false
 
 [[bin]]
+name = "encode_u32_iter"
+path = "fuzz_targets/encode_u32_iter.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "decode_u32"
 path = "fuzz_targets/decode_u32.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "decode_u32_iter"
+path = "fuzz_targets/decode_u32_iter.rs"
 test = false
 doc = false
 

--- a/fuzz/fuzz_targets/decode_u32_iter.rs
+++ b/fuzz/fuzz_targets/decode_u32_iter.rs
@@ -1,0 +1,15 @@
+#![no_main]
+
+use std::hint::black_box;
+
+use libfuzzer_sys::fuzz_target;
+use prefix_uvarint::PrefixVarIntBuf;
+
+fuzz_target!(|data: &[u8]| {
+    // attempts to decode all the data as a u32 error are ok, panics are not
+    let mut src = data;
+    let iter = src.iter_prefix_varint::<u32>();
+    for v in iter {
+        let _ = black_box(v);
+    }
+});

--- a/fuzz/fuzz_targets/decode_u32_iter.rs
+++ b/fuzz/fuzz_targets/decode_u32_iter.rs
@@ -7,7 +7,7 @@ use prefix_uvarint::PrefixVarIntBuf;
 
 fuzz_target!(|data: &[u8]| {
     // attempts to decode all the data as a u32 error are ok, panics are not
-    let mut src = data;
+    let src = data;
     let iter = src.iter_prefix_varint::<u32>();
     for v in iter {
         let _ = black_box(v);

--- a/fuzz/fuzz_targets/encode_u32_iter.rs
+++ b/fuzz/fuzz_targets/encode_u32_iter.rs
@@ -1,0 +1,25 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use prefix_uvarint::{PrefixVarIntBuf, PrefixVarIntBufMut};
+
+fuzz_target!(|data: &[u8]| {
+    let mut dst = vec![];
+    let mut decoded = vec![];
+    for chunk in data.chunks_exact(4) {
+        let mut buf = [0; 4];
+        buf.copy_from_slice(chunk);
+        let n = u32::from_le_bytes(buf);
+        decoded.push(n);
+        dst.put_prefix_varint(n);
+    }
+
+    let mut src = &dst[..];
+    let iter = src.iter_prefix_varint::<u32>();
+    for (decoded, truth) in iter.zip(decoded.iter()) {
+        assert_eq!(decoded.unwrap(), *truth);
+    }
+    
+    // check that the iterator is exhausted
+    assert!(src.iter_prefix_varint::<u32>().next().is_none());
+});

--- a/fuzz/fuzz_targets/encode_u32_iter.rs
+++ b/fuzz/fuzz_targets/encode_u32_iter.rs
@@ -14,12 +14,12 @@ fuzz_target!(|data: &[u8]| {
         dst.put_prefix_varint(n);
     }
 
-    let mut src = &dst[..];
+    let src = &dst[..];
     let iter = src.iter_prefix_varint::<u32>();
     for (decoded, truth) in iter.zip(decoded.iter()) {
         assert_eq!(decoded.unwrap(), *truth);
     }
-    
+
     // check that the iterator is exhausted
     assert!(src.iter_prefix_varint::<u32>().next().is_none());
 });

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -112,7 +112,7 @@ pub trait PrefixVarIntBuf {
     ///
     /// Returns an `Overflow` error if the encoded value is larger than the
     /// maximum value that can be represented by the `PrefixVarInt` type.
-    fn iter_prefix_varint<PV: PrefixVarInt>(&mut self) -> PrefixVarIntIter<'_, PV, Self>
+    fn iter_prefix_varint<PV: PrefixVarInt>(self) -> PrefixVarIntIter<PV, Self>
     where
         Self: Sized,
     {
@@ -148,15 +148,15 @@ impl<Inner: Buf> PrefixVarIntBuf for Inner {
 
 /// An iterator over `PrefixVarInt` values in a `Buf`.
 #[derive(Debug)]
-pub struct PrefixVarIntIter<'a, PV, B> {
-    buf: &'a mut B,
+pub struct PrefixVarIntIter<PV, B> {
+    buf: B,
     _marker: std::marker::PhantomData<PV>,
 }
 
 // new method
-impl<'a, PV, B> PrefixVarIntIter<'a, PV, B> {
+impl<PV, B> PrefixVarIntIter<PV, B> {
     /// Creates a new `PrefixVarIntIter`.
-    pub fn new(buf: &'a mut B) -> Self {
+    pub fn new(buf: B) -> Self {
         Self {
             buf,
             _marker: std::marker::PhantomData,
@@ -164,7 +164,7 @@ impl<'a, PV, B> PrefixVarIntIter<'a, PV, B> {
     }
 }
 
-impl<'a, PV, B> Iterator for PrefixVarIntIter<'a, PV, B>
+impl<PV, B> Iterator for PrefixVarIntIter<PV, B>
 where
     B: Buf,
     PV: PrefixVarInt,

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -112,7 +112,7 @@ pub trait PrefixVarIntBuf {
     ///
     /// Returns an `Overflow` error if the encoded value is larger than the
     /// maximum value that can be represented by the `PrefixVarInt` type.
-    fn iter_prefix_varint<PV: PrefixVarInt>(&mut self) -> PrefixVarIntIter<'_, Self, PV>
+    fn iter_prefix_varint<PV: PrefixVarInt>(&mut self) -> PrefixVarIntIter<'_, PV, Self>
     where
         Self: Sized,
     {
@@ -147,13 +147,13 @@ impl<Inner: Buf> PrefixVarIntBuf for Inner {
 }
 
 /// An iterator over `PrefixVarInt` values in a `Buf`.
-pub struct PrefixVarIntIter<'a, B, PV> {
+pub struct PrefixVarIntIter<'a, PV, B> {
     buf: &'a mut B,
     _marker: std::marker::PhantomData<PV>,
 }
 
 // new method
-impl<'a, B, PV> PrefixVarIntIter<'a, B, PV> {
+impl<'a, PV, B> PrefixVarIntIter<'a, PV, B> {
     /// Creates a new `PrefixVarIntIter`.
     pub fn new(buf: &'a mut B) -> Self {
         Self {
@@ -163,7 +163,7 @@ impl<'a, B, PV> PrefixVarIntIter<'a, B, PV> {
     }
 }
 
-impl<'a, B, PV> Iterator for PrefixVarIntIter<'a, B, PV>
+impl<'a, PV, B> Iterator for PrefixVarIntIter<'a, PV, B>
 where
     B: Buf,
     PV: PrefixVarInt,

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -22,6 +22,7 @@ pub trait PrefixVarIntBufMut {
 }
 
 impl<Inner: BufMut> PrefixVarIntBufMut for Inner {
+    /// Writes a `PrefixVarInt` value to the buffer.
     #[inline]
     fn put_prefix_varint<PV: PrefixVarInt>(&mut self, v: PV) {
         let raw = v.to_prefix_varint_raw();
@@ -53,7 +54,70 @@ fn get_prefix_varint_slow<B: Buf>(tag: u8, buf: &mut B) -> Result<u64, DecodeErr
 
 /// Extension for `buf::Buf` to read any `PrefixVarInt` type.
 pub trait PrefixVarIntBuf {
+    /// Reads a `PrefixVarInt` from the buffer. After a successful read, the
+    /// buffer will be advanced by the number of bytes read.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use prefix_uvarint::{PrefixVarIntBufMut, PrefixVarIntBuf};
+    ///
+    /// let to_encode = [1, 2, 400];
+    /// let mut buf = vec![];
+    /// for v in &to_encode {
+    ///    buf.put_prefix_varint(*v);
+    /// }
+    ///
+    /// let mut buf = &buf[..];
+    /// for v in &to_encode {
+    ///   let decoded = buf.get_prefix_varint::<u16>().unwrap();
+    ///   assert_eq!(decoded, *v);
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an `UnexpectedEob` error if the buffer is empty or if the buffer
+    /// is not long enough to contain the full encoded value.
+    ///
+    /// Returns an `Overflow` error if the encoded value is larger than the
+    /// maximum value that can be represented by the `PrefixVarInt` type.
     fn get_prefix_varint<PV: PrefixVarInt>(&mut self) -> Result<PV, DecodeError>;
+
+    // iter_prefix_varint method
+    /// Returns an iterator over `PrefixVarInt` values in the buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use prefix_uvarint::{PrefixVarIntBufMut, PrefixVarIntBuf};
+    ///
+    /// let to_encode = [1, 2, -30, -24_000];
+    /// let mut buf = vec![];
+    /// for n in to_encode.iter() {
+    ///     buf.put_prefix_varint(*n);
+    /// }
+    /// let mut result = vec![];
+    /// let mut decode_data = buf.as_slice();
+    /// for decoded in decode_data.iter_prefix_varint::<i16>() {
+    ///     result.push(decoded.unwrap());
+    /// }
+    /// assert_eq!(to_encode, result.as_slice());
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an `UnexpectedEob` error if the buffer is empty or if the buffer
+    /// is not long enough to contain the full encoded value.
+    ///
+    /// Returns an `Overflow` error if the encoded value is larger than the
+    /// maximum value that can be represented by the `PrefixVarInt` type.
+    fn iter_prefix_varint<PV: PrefixVarInt>(&mut self) -> PrefixVarIntIter<'_, Self, PV>
+    where
+        Self: Sized,
+    {
+        PrefixVarIntIter::new(self)
+    }
 }
 
 impl<Inner: Buf> PrefixVarIntBuf for Inner {
@@ -78,6 +142,40 @@ impl<Inner: Buf> PrefixVarIntBuf for Inner {
         } else {
             PV::from_prefix_varint_raw(get_prefix_varint_slow(tag, self)?)
                 .ok_or(DecodeError::Overflow)
+        }
+    }
+}
+
+/// An iterator over `PrefixVarInt` values in a `Buf`.
+pub struct PrefixVarIntIter<'a, B, PV> {
+    buf: &'a mut B,
+    _marker: std::marker::PhantomData<PV>,
+}
+
+// new method
+impl<'a, B, PV> PrefixVarIntIter<'a, B, PV> {
+    /// Creates a new `PrefixVarIntIter`.
+    pub fn new(buf: &'a mut B) -> Self {
+        Self {
+            buf,
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<'a, B, PV> Iterator for PrefixVarIntIter<'a, B, PV>
+where
+    B: Buf,
+    PV: PrefixVarInt,
+{
+    type Item = Result<PV, DecodeError>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.buf.has_remaining() {
+            Some(self.buf.get_prefix_varint())
+        } else {
+            None
         }
     }
 }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -178,4 +178,9 @@ where
             None
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let bytes_remaining = self.buf.remaining();
+        (bytes_remaining / MAX_LEN, Some(bytes_remaining))
+    }
 }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -147,6 +147,7 @@ impl<Inner: Buf> PrefixVarIntBuf for Inner {
 }
 
 /// An iterator over `PrefixVarInt` values in a `Buf`.
+#[derive(Debug)]
 pub struct PrefixVarIntIter<'a, PV, B> {
     buf: &'a mut B,
     _marker: std::marker::PhantomData<PV>,

--- a/src/core.rs
+++ b/src/core.rs
@@ -103,7 +103,10 @@ pub struct EncodedPrefixVarInt {
 #[allow(clippy::len_without_is_empty)]
 impl EncodedPrefixVarInt {
     fn new(v: u64) -> Self {
-        let mut enc = Self::default();
+        let mut enc = Self {
+            buf: [0u8; MAX_LEN],
+            len: 0,
+        };
         let len = unsafe { raw::encode(v, enc.buf.as_mut_ptr()) };
         enc.len = len as u8;
         enc
@@ -116,15 +119,6 @@ impl EncodedPrefixVarInt {
     /// Returns the number of bytes used to encode the value.
     pub fn len(&self) -> usize {
         self.len as usize
-    }
-}
-
-impl Default for EncodedPrefixVarInt {
-    fn default() -> Self {
-        Self {
-            buf: [0u8; MAX_LEN],
-            len: 0,
-        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ mod raw;
 #[cfg(test)]
 mod tests;
 
-pub use crate::bytes::{PrefixVarIntBuf, PrefixVarIntBufMut};
+pub use crate::bytes::{PrefixVarIntBuf, PrefixVarIntBufMut, PrefixVarIntIter};
 pub use crate::core::{DecodeError, EncodedPrefixVarInt, PrefixVarInt};
 pub use crate::io::{read_prefix_varint, read_prefix_varint_buf, write_prefix_varint};
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -237,6 +237,20 @@ mod buf {
         // more valid varints, and so the lower bound is 0.
         assert_eq!(iter.size_hint(), (0, Some(8)));
     }
+
+    #[test]
+    fn iterator_continues_after_error() {
+        let to_encode = [1u32, 70_000, 2];
+        let mut buf = vec![];
+        for n in to_encode.iter() {
+            buf.put_prefix_varint(*n);
+        }
+        let mut decode_data = buf.as_slice();
+        let mut iter = decode_data.iter_prefix_varint::<u16>();
+        assert_eq!(iter.next(), Some(Ok(1)));
+        assert_eq!(iter.next(), Some(Err(DecodeError::Overflow)));
+        assert_eq!(iter.next(), Some(Ok(2)));
+    }
 }
 
 mod io {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -104,6 +104,7 @@ mod buf {
     macro_rules! test_random_buf_put_get {
         ($int:ty, $name:ident) => {
             #[test]
+            #[cfg_attr(miri, ignore)]
             fn $name() {
                 for (min, max) in <$int>::prefix_varint_bounds() {
                     let input_values = generate_array(RANDOM_TEST_LEN, min, max);
@@ -246,6 +247,7 @@ mod io {
     macro_rules! test_random_io_write_read {
         ($name:ident, $int:ty) => {
             #[test]
+            #[cfg_attr(miri, ignore)]
             fn $name() {
                 for (min, max) in <$int>::prefix_varint_bounds() {
                     let input_values = generate_array(RANDOM_TEST_LEN, min, max);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -208,10 +208,16 @@ mod buf {
         for n in to_encode.iter() {
             buf.put_prefix_varint(*n);
         }
-        let mut result = vec![];
-        for decoded in buf.iter_prefix_varint::<i16>() {
-            result.push(decoded.unwrap());
-        }
+        assert_eq!(buf.len(), 6);
+        assert_eq!(
+            to_encode,
+            buf.iter_prefix_varint::<i16>()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+                .as_slice()
+        );
+        // check that buf was not consumed
+        assert_eq!(buf.len(), 6);
     }
 
     #[test]
@@ -221,11 +227,14 @@ mod buf {
         for n in to_encode.iter() {
             buf.put_prefix_varint(*n);
         }
-        let mut result = vec![];
         let buf = VecDeque::from(buf);
-        for decoded in buf.iter_prefix_varint::<i16>() {
-            result.push(decoded.unwrap());
-        }
+        assert_eq!(
+            to_encode,
+            buf.iter_prefix_varint::<i16>()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+                .as_slice()
+        );
     }
 
     #[test]


### PR DESCRIPTION
- add iterator to public api
- bump version to account for changes to api in this and previous PR
- varint iterator on Buf should be consuming, this allows for slices and avoids needless restrictions on what can be iterated over. Things such as Vec<u8> will deref into a  `&[u8]` so will not be consuming.