### PR TITLE
Optimize varint writer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prefix_uvarint"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Trevor McCulloch <mccullocht@gmail.com>"]
 edition = "2021"
 description = "Prefix based variable length integer coding."

--- a/src/core.rs
+++ b/src/core.rs
@@ -113,7 +113,8 @@ impl EncodedPrefixVarInt {
     }
 
     pub fn as_slice(&self) -> &[u8] {
-        &self.buf[..self.len()]
+        // SAFETY: `self.buf` is initialized to the correct length in `new()`.
+        unsafe { std::slice::from_raw_parts(self.buf.as_ptr(), self.len as usize) }
     }
 
     /// Returns the number of bytes used to encode the value.

--- a/src/core.rs
+++ b/src/core.rs
@@ -114,6 +114,7 @@ impl EncodedPrefixVarInt {
 
     pub fn as_slice(&self) -> &[u8] {
         // SAFETY: `self.buf` is initialized to the correct length in `new()`.
+        // from_raw_parts is used over slice indexing to avoid bounds checks.
         unsafe { std::slice::from_raw_parts(self.buf.as_ptr(), self.len as usize) }
     }
 


### PR DESCRIPTION
This PR attempts to optimize the prefix varint write interface. I had noticed in practice I was getting lower speeds than expected. The old method, while convenient, was very stack unfriendly. This new one inlines 1 and 2 byte writes and adds an encoder function similar to the pointer one.

Inlining the second byte was a huge boost to performance and still a fairly common codepath.

|num_bytes|ns_per_op|ns_per_op_main|speedup|
|---------|---------|--------------|-------|
|    1    |   1.11  |     3.29     |  2.96 |
|    2    |   1.21  |     3.15     |  2.6  |
|    3    |   2.24  |     3.58     |  1.6  |
|    4    |   2.24  |     3.57     |  1.59 |
|    5    |   2.68  |     3.99     |  1.49 |
|    6    |   2.9   |     4.21     |  1.45 |
|    7    |   3.32  |     4.21     |  1.27 |
|    8    |   6.12  |     4.65     |  0.76 |
|    9    |   6.13  |     5.05     |  0.82 |